### PR TITLE
Fix broken links in Samples README's

### DIFF
--- a/sample/counter/README.md
+++ b/sample/counter/README.md
@@ -1,3 +1,3 @@
 # Sample Counter App
 
-Please refer to the corresponding [documentation page](https://arkivanov.github.io/Decompose/samples/#sample-counter-app) for the description.
+Please refer to the corresponding [documentation page](https://arkivanov.github.io/Decompose/getting-started/samples/#sample-counter-app) for the description.

--- a/sample/master-detail/README.md
+++ b/sample/master-detail/README.md
@@ -1,5 +1,5 @@
 # Sample Master-Detail App
 
-> ⚠  This sample is for advanced single-pane/multi-pane navigation and layout, for generic master-detail navigation please refer to the [Sample Todo List App](https://arkivanov.github.io/Decompose/samples/#sample-todo-list-app).
+> ⚠  This sample is for advanced single-pane/multi-pane navigation and layout, for generic master-detail navigation please refer to the [Sample Todo List App](https://arkivanov.github.io/Decompose/getting-started/samples/#sample-todo-list-app).
 
-Please refer to the corresponding [documentation page](https://arkivanov.github.io/Decompose/samples/#sample-master-detail-app) for the description.
+Please refer to the corresponding [documentation page](https://arkivanov.github.io/Decompose/getting-started/samples/#sample-master-detail-app) for the description.


### PR DESCRIPTION
Just fixed links that pointed to samples in the docs since the URL changed from /samples to /getting-started/samples