### PR TITLE
Add extension for accessing Router's active Child

### DIFF
--- a/decompose/api/android/decompose.api
+++ b/decompose/api/android/decompose.api
@@ -80,6 +80,7 @@ public abstract interface class com/arkivanov/decompose/router/Router {
 
 public final class com/arkivanov/decompose/router/RouterExtKt {
 	public static final fun bringToFront (Lcom/arkivanov/decompose/router/Router;Ljava/lang/Object;)V
+	public static final fun getActiveChild (Lcom/arkivanov/decompose/router/Router;)Lcom/arkivanov/decompose/Child$Created;
 	public static final fun pop (Lcom/arkivanov/decompose/router/Router;)V
 	public static final fun popWhile (Lcom/arkivanov/decompose/router/Router;Lkotlin/jvm/functions/Function1;)V
 	public static final fun push (Lcom/arkivanov/decompose/router/Router;Ljava/lang/Object;)V

--- a/decompose/api/jvm/decompose.api
+++ b/decompose/api/jvm/decompose.api
@@ -67,6 +67,7 @@ public abstract interface class com/arkivanov/decompose/router/Router {
 
 public final class com/arkivanov/decompose/router/RouterExtKt {
 	public static final fun bringToFront (Lcom/arkivanov/decompose/router/Router;Ljava/lang/Object;)V
+	public static final fun getActiveChild (Lcom/arkivanov/decompose/router/Router;)Lcom/arkivanov/decompose/Child$Created;
 	public static final fun pop (Lcom/arkivanov/decompose/router/Router;)V
 	public static final fun popWhile (Lcom/arkivanov/decompose/router/Router;Lkotlin/jvm/functions/Function1;)V
 	public static final fun push (Lcom/arkivanov/decompose/router/Router;Ljava/lang/Object;)V

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/RouterExt.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/RouterExt.kt
@@ -38,4 +38,5 @@ fun <C : Any> Router<C, *>.bringToFront(configuration: C) {
     }
 }
 
-val <C : Any> Router<C, *>.activeConfiguration: C get() = state.value.activeChild.configuration
+val <C : Any> RouterState<C, *>.activeConfiguration: C get() = activeChild.configuration
+val <C : Any> Router<C, *>.activeConfiguration: C get() = state.value.activeConfiguration

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/RouterExt.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/RouterExt.kt
@@ -37,3 +37,5 @@ fun <C : Any> Router<C, *>.bringToFront(configuration: C) {
         stack.filterNot { it::class == configuration::class } + configuration
     }
 }
+
+val <C : Any> Router<C, *>.activeConfiguration: C get() = state.value.activeChild.configuration

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/RouterExt.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/RouterExt.kt
@@ -1,5 +1,7 @@
 package com.arkivanov.decompose.router
 
+import com.arkivanov.decompose.Child
+
 /**
  * Pushes the provided [configuration] at the top of the stack
  */
@@ -38,5 +40,4 @@ fun <C : Any> Router<C, *>.bringToFront(configuration: C) {
     }
 }
 
-val <C : Any> RouterState<C, *>.activeConfiguration: C get() = activeChild.configuration
-val <C : Any> Router<C, *>.activeConfiguration: C get() = state.value.activeConfiguration
+val <C : Any, T : Any> Router<C, T>.activeChild: Child.Created<C, T> get() = state.value.activeChild

--- a/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/DetailsRouter.kt
+++ b/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/DetailsRouter.kt
@@ -2,6 +2,7 @@ package com.arkivanov.sample.masterdetail.shared.root
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.RouterState
+import com.arkivanov.decompose.router.activeConfiguration
 import com.arkivanov.decompose.router.popWhile
 import com.arkivanov.decompose.router.router
 import com.arkivanov.decompose.value.Value
@@ -57,7 +58,7 @@ internal class DetailsRouter(
     }
 
     fun isShown(): Boolean =
-        when (router.state.value.activeChild.configuration) {
+        when (router.activeConfiguration) {
             is Config.None -> false
             is Config.Details -> true
         }

--- a/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/DetailsRouter.kt
+++ b/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/DetailsRouter.kt
@@ -2,7 +2,7 @@ package com.arkivanov.sample.masterdetail.shared.root
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.RouterState
-import com.arkivanov.decompose.router.activeConfiguration
+import com.arkivanov.decompose.router.activeChild
 import com.arkivanov.decompose.router.popWhile
 import com.arkivanov.decompose.router.router
 import com.arkivanov.decompose.value.Value
@@ -58,7 +58,7 @@ internal class DetailsRouter(
     }
 
     fun isShown(): Boolean =
-        when (router.activeConfiguration) {
+        when (router.activeChild.configuration) {
             is Config.None -> false
             is Config.Details -> true
         }

--- a/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/ListRouter.kt
+++ b/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/ListRouter.kt
@@ -2,7 +2,7 @@ package com.arkivanov.sample.masterdetail.shared.root
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.RouterState
-import com.arkivanov.decompose.router.activeConfiguration
+import com.arkivanov.decompose.router.activeChild
 import com.arkivanov.decompose.router.pop
 import com.arkivanov.decompose.router.push
 import com.arkivanov.decompose.router.router
@@ -46,13 +46,13 @@ internal class ListRouter(
         )
 
     fun moveToBackStack() {
-        if (router.activeConfiguration !is Config.None) {
+        if (router.activeChild.configuration !is Config.None) {
             router.push(Config.None)
         }
     }
 
     fun show() {
-        if (router.activeConfiguration !is Config.List) {
+        if (router.activeChild.configuration !is Config.List) {
             router.pop()
         }
     }

--- a/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/ListRouter.kt
+++ b/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/ListRouter.kt
@@ -2,6 +2,7 @@ package com.arkivanov.sample.masterdetail.shared.root
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.RouterState
+import com.arkivanov.decompose.router.activeConfiguration
 import com.arkivanov.decompose.router.pop
 import com.arkivanov.decompose.router.push
 import com.arkivanov.decompose.router.router
@@ -45,13 +46,13 @@ internal class ListRouter(
         )
 
     fun moveToBackStack() {
-        if (router.state.value.activeChild.configuration !is Config.None) {
+        if (router.activeConfiguration !is Config.None) {
             router.push(Config.None)
         }
     }
 
     fun show() {
-        if (router.state.value.activeChild.configuration !is Config.List) {
+        if (router.activeConfiguration !is Config.List) {
             router.pop()
         }
     }

--- a/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/RootComponent.kt
+++ b/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/RootComponent.kt
@@ -2,7 +2,6 @@ package com.arkivanov.sample.masterdetail.shared.root
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.RouterState
-import com.arkivanov.decompose.router.activeConfiguration
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.observe
@@ -55,7 +54,7 @@ class RootComponent(
         }
 
         detailsRouter.state.observe(lifecycle) {
-            selectedArticleIdSubject.onNext(it.activeConfiguration.getArticleId())
+            selectedArticleIdSubject.onNext(it.activeChild.configuration.getArticleId())
         }
     }
 

--- a/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/RootComponent.kt
+++ b/sample/master-detail/shared/src/commonMain/kotlin/com/arkivanov/sample/masterdetail/shared/root/RootComponent.kt
@@ -2,6 +2,7 @@ package com.arkivanov.sample.masterdetail.shared.root
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.RouterState
+import com.arkivanov.decompose.router.activeConfiguration
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.observe
@@ -54,7 +55,7 @@ class RootComponent(
         }
 
         detailsRouter.state.observe(lifecycle) {
-            selectedArticleIdSubject.onNext(it.activeChild.configuration.getArticleId())
+            selectedArticleIdSubject.onNext(it.activeConfiguration.getArticleId())
         }
     }
 


### PR DESCRIPTION
Instead of having to type out `router.state.value.activeChild` every time you want to access the active Child, this PR adds an extension that is much shorter:

`router.activeChild` (Router)