### PR TITLE
Document correct lifecycle setup for compose-jb

### DIFF
--- a/docs/extensions/compose.md
+++ b/docs/extensions/compose.md
@@ -59,7 +59,7 @@ fun SomeContent(component: SomeComponent) {
 }
 ```
 
-### Lifecycle
+### Controlling the Lifecycle on Desktop
 
 When using JetBrains Compose, you can have a `LifecycleRegistry` react to changes in the window state using the `LifecycleController()` composable. This will trigger appropriate lifecycle events when the window is minimized, restored or closed.
 
@@ -86,9 +86,7 @@ fun main() {
 }
 ```
 
-
-
-> Warning: When using Compose in desktop platforms, make sure to always use one of the methods above, or your components might not receive lifecycle events correctly.
+> ⚠️ When using Compose in desktop platforms, make sure to always use one of the methods above, or your components might not receive lifecycle events correctly.
 
 ### Navigating between Composable components
 

--- a/docs/extensions/compose.md
+++ b/docs/extensions/compose.md
@@ -59,6 +59,37 @@ fun SomeContent(component: SomeComponent) {
 }
 ```
 
+### Lifecycle
+
+When using JetBrains Compose, you can have a `LifecycleRegistry` react to changes in the window state using the `LifecycleController()` composable. This will trigger appropriate lifecycle events when the window is minimized, restored or closed.
+
+It is also possible to manually start the lifecycle using `LifecycleRegistry.resume()` when the instance is created.
+
+```kotlin
+fun main() {
+    val lifecycle = LifecycleRegistry()
+    val root = RootComponent(DefaultComponentContext(lifecycle))
+    
+    // Alternative: manually start the lifecycle (no reaction to window state)
+    // lifecycle.resume()
+    
+    application {
+        val windowState = rememberWindowState()
+        
+        // Bind the registry to the life cycle of the window
+        LifecycleController(lifecycle, windowState)
+        
+        Window(state = windowState, ...) {
+            // The rest of your content
+        }
+    }
+}
+```
+
+
+
+> Warning: When using Compose in desktop platforms, make sure to always use one of the methods above, or your components might not receive lifecycle events correctly.
+
 ### Navigating between Composable components
 
 The [Router](https://arkivanov.github.io/Decompose/router/overview/) provides


### PR DESCRIPTION
This PR adds a section in the documentation about the correct usage of `LifecycleRegistry` when working with JetBrains Compose. Fixes #78.