### PR TITLE
fix tabs for mkdocs documentation and add the maven cental badge to the setup page

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,4 +1,4 @@
-Decompose provides a number of modules, they all published to Maven Central Repository.
+Decompose provides a number of modules, they are all published to Maven Central Repository. [![Maven Central](https://img.shields.io/maven-central/v/com.arkivanov.decompose/decompose?color=blue)](https://search.maven.org/artifact/com.arkivanov.decompose/decompose)
 
 ## The main Decompose module
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true 
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde


### PR DESCRIPTION
Material Mkdocs changed how tabs work in the documentation so I added this to the configuration file so they actually work as tabs now. I also added the maven central badge for decompose so its easier for new users to know which versions are available in the documentation. 

## Before 
![Screen Shot 2022-05-11 at 12 25 16](https://user-images.githubusercontent.com/31364841/167929789-d2f7b94c-ae2f-4c5a-a53f-97b66684421d.png)

## After
![Screen Shot 2022-05-11 at 12 23 15](https://user-images.githubusercontent.com/31364841/167929718-253db7e9-bf0e-42fd-b441-f920bf9d7d74.png)

