### PR TITLE
update docs warning of child context to use material mkdocs admonition for a clearer warning that stands out in docs

### DIFF
--- a/docs/component/overview.md
+++ b/docs/component/overview.md
@@ -189,7 +189,8 @@ class SomeParent(
 }
 ```
 
-> ⚠️ Never pass parent's `ComponentContext` to children, always use either the `Router` or the `childContext(...)` function.
+!!!warning 
+    Never pass parent's `ComponentContext` to children, always use either the `Router` or the `childContext(...)` function.
 
 ## Examples
 


### PR DESCRIPTION
![Screen Shot 2022-05-11 at 12 34 16](https://user-images.githubusercontent.com/31364841/167931299-b16a0ccd-e15a-4945-8c0c-a6763f6c9f54.png)

From the [discussion thread](https://github.com/arkivanov/Decompose/discussions/99#discussioncomment-2732807)

## Resources 

https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types