### PR TITLE
[compose-darwin] Removed kotlin.native.cacheKind=none workaround

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,10 +13,3 @@ org.jetbrains.compose.experimental.jscanvas.enabled=true
 
 # Workaround for https://issuetracker.google.com/issues/185418482
 android.experimental.lint.version=8.0.0-alpha10
-
-# Workaround for a build failure on CI:
-# e: Module "org.jetbrains.compose.runtime:runtime-saveable (org.jetbrains.compose.runtime:runtime-saveable-uikitx64)"
-# has a reference to symbol androidx.compose.runtime/remember|-2215966373931868872[0]. Neither the module itself nor
-# its dependencies contain such declaration.
-# See: https://github.com/JetBrains/compose-jb/issues/2046
-kotlin.native.cacheKind=none


### PR DESCRIPTION
This PR is for `compose-darwin` branch.

As part of #74.