### PR TITLE
add `replaceAll` extension function for `StackNavigator`

### DIFF
--- a/decompose/api/android/decompose.api
+++ b/decompose/api/android/decompose.api
@@ -177,6 +177,8 @@ public final class com/arkivanov/decompose/router/stack/StackNavigatorExtKt {
 	public static final fun popWhile (Lcom/arkivanov/decompose/router/stack/StackNavigator;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static final fun push (Lcom/arkivanov/decompose/router/stack/StackNavigator;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun push$default (Lcom/arkivanov/decompose/router/stack/StackNavigator;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun replaceAll (Lcom/arkivanov/decompose/router/stack/StackNavigator;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun replaceAll$default (Lcom/arkivanov/decompose/router/stack/StackNavigator;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun replaceCurrent (Lcom/arkivanov/decompose/router/stack/StackNavigator;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun replaceCurrent$default (Lcom/arkivanov/decompose/router/stack/StackNavigator;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }

--- a/decompose/api/jvm/decompose.api
+++ b/decompose/api/jvm/decompose.api
@@ -164,6 +164,8 @@ public final class com/arkivanov/decompose/router/stack/StackNavigatorExtKt {
 	public static final fun popWhile (Lcom/arkivanov/decompose/router/stack/StackNavigator;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static final fun push (Lcom/arkivanov/decompose/router/stack/StackNavigator;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun push$default (Lcom/arkivanov/decompose/router/stack/StackNavigator;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun replaceAll (Lcom/arkivanov/decompose/router/stack/StackNavigator;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun replaceAll$default (Lcom/arkivanov/decompose/router/stack/StackNavigator;[Ljava/lang/Object;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun replaceCurrent (Lcom/arkivanov/decompose/router/stack/StackNavigator;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun replaceCurrent$default (Lcom/arkivanov/decompose/router/stack/StackNavigator;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/StackNavigatorExt.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/StackNavigatorExt.kt
@@ -71,7 +71,7 @@ fun <C : Any> StackNavigator<C>.replaceCurrent(configuration: C, onComplete: () 
  * @param onComplete called when the navigation is finished (either synchronously or asynchronously).
  */
 fun <C : Any> StackNavigator<C>.replaceAll(vararg configurations: C, onComplete: () -> Unit = { }) {
-    navigate(transformer = { configurations.toList() }, onComplete = { _,_->onComplete() })
+    navigate(transformer = { configurations.toList() }, onComplete = { _, _ -> onComplete() })
 }
 
 /**

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/StackNavigatorExt.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/StackNavigatorExt.kt
@@ -66,6 +66,15 @@ fun <C : Any> StackNavigator<C>.replaceCurrent(configuration: C, onComplete: () 
 }
 
 /**
+ * Replaces the whole stack with the provided [configurations].
+ *
+ * @param onComplete called when the navigation is finished (either synchronously or asynchronously).
+ */
+fun <C : Any> StackNavigator<C>.replaceAll(vararg configurations: C, onComplete: () -> Unit = { }) {
+    navigate(transformer = { configurations.toList() }, onComplete = { _,_->onComplete() })
+}
+
+/**
  * Removes all components with configurations of [configuration]'s class, and adds the provided [configuration] to the top of the stack.
  * The operation is performed as one transaction. If there is already a component with the same configuration, it will not be recreated.
  */

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/stack/RouterReplaceAllTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/stack/RouterReplaceAllTest.kt
@@ -1,0 +1,28 @@
+package com.arkivanov.decompose.router.stack
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Suppress("TestFunctionName")
+class RouterReplaceAllTest {
+
+    @Test
+    fun WHEN_replaceAll_THEN_configurations_correctly_applied() {
+        val navigator = TestStackNavigator(listOf(1, 2, 3))
+
+        navigator.replaceAll(3, 4, 5)
+
+        assertEquals(listOf(3, 4, 5), navigator.configurations)
+    }
+
+    @Test
+    fun WHEN_replace_all_THEN_onComplete_called() {
+        val navigator = TestStackNavigator(listOf(1, 2, 3))
+        var isCalled = false
+
+        navigator.replaceAll(4) { isCalled = true }
+
+        assertTrue(isCalled)
+    }
+}


### PR DESCRIPTION
This adds an extension function to `StackNavigator` called `replaceAll`. It's main purpose is to serve as a convenient alternative to the `navigate` pair of functions. By taking in the Configurations as varargs some boilerplate is eliminated (if the user does not intend to build upon the current stack, that is)

Thanks @arkivanov for the constructive discussion :)