### PR TITLE
Update docs for `childOverlay` with custom component context

### DIFF
--- a/docs/component/custom-component-context.md
+++ b/docs/component/custom-component-context.md
@@ -22,64 +22,7 @@ class DefaultAppComponentContext(
 }
 ```
 
-## How to initialize Child Stack with custom ComponentContext
+## Custom ComponentContext with navigation
 
-In order to pass this `AppComponentContext` to child components, make an extension function on the `AppComponentContext` interface. This custom extension function will initialize the `Child Stack` and provide child `AppComponentContext`.
-
-```kotlin
-fun <C : Parcelable, T : Any> AppComponentContext.appChildStack(
-    source: StackNavigationSource<C>,
-    initialStack: () -> List<C>,
-    configurationClass: KClass<out C>,
-    key: String = "DefaultStack",
-    handleBackButton: Boolean = false,
-    childFactory: (configuration: C, AppComponentContext) -> T
-): Value<ChildStack<C, T>> =
-    childStack(
-        source = source,
-        initialStack = initialStack,
-        configurationClass = configurationClass,
-        key = key,
-        handleBackButton = handleBackButton
-    ) { configuration, componentContext ->
-        childFactory(
-            configuration,
-            DefaultAppComponentContext(
-                componentContext = componentContext
-            )
-        )
-    }
-
-inline fun <reified C : Parcelable, T : Any> AppComponentContext.appChildStack(
-    source: StackNavigationSource<C>,
-    noinline initialStack: () -> List<C>,
-    key: String = "DefaultStack",
-    handleBackButton: Boolean = false,
-    noinline childFactory: (configuration: C, AppComponentContext) -> T
-): Value<ChildStack<C, T>> =
-    appChildStack(
-        source = source,
-        initialStack = initialStack,
-        configurationClass = C::class,
-        key = key,
-        handleBackButton = handleBackButton,
-        childFactory = childFactory,
-    )
-```
-
-Finally, in your components you can create the new extension function that will utilize the new custom `AppComponentContext`.
-
-```kotlin
-class MyComponent(componentContext: AppComponentContext) : AppComponentContext by componentContext {
-
-    private val navigation = StackNavigation<Configuration>()
-
-    private val childStack = appChildStack(
-        source = navigation,
-        initialStack = { listOf(Configuration.Home) },
-        childFactory = { configuration, appComponentContext ->
-            // return child components using the custom component context
-        }
-    )
-}
-```
+- [With Child Stack](../navigation/stack/component-context.md)
+- [With Child Overlay](../navigation/overlay/component-context.md)

--- a/docs/component/custom-component-context.md
+++ b/docs/component/custom-component-context.md
@@ -22,7 +22,7 @@ class DefaultAppComponentContext(
 }
 ```
 
-## Custom ComponentContext with navigation
+## Navigation with custom ComponentContext
 
-- [With Child Stack](../navigation/stack/component-context.md)
-- [With Child Overlay](../navigation/overlay/component-context.md)
+- [Using Child Stack](../navigation/stack/component-context.md)
+- [Using Child Overlay](../navigation/overlay/component-context.md)

--- a/docs/navigation/overlay/component-context.md
+++ b/docs/navigation/overlay/component-context.md
@@ -1,0 +1,69 @@
+# How to initialize Child Overlay with custom ComponentContext 
+
+In order to pass this `AppComponentContext` to child overlay components, make an extension function on the `AppComponentContext` interface. This custom extension function will initialize the `Child Overlay` and provide child `AppComponentContext`.
+
+```kotlin
+fun <C : Parcelable, T : Any> AppComponentContext.appChildOverlay(
+    source: OverlayNavigationSource<C>,
+    initialConfiguration: () -> C?,
+    configurationClass: KClass<out C>,
+    key: String = "DefaultOverlay",
+    handleBackButton: Boolean = false,
+    persistent: Boolean = false,
+    childFactory: (configuration: C, AppComponentContext) -> T
+): Value<ChildOverlay<C, T>> =
+    childOverlay(
+        source = source,
+        configurationClass = configurationClass,
+        key = key,
+        handleBackButton = handleBackButton,
+        initialConfiguration = initialConfiguration,
+        persistent = persistent
+    ) { configuration, componentContext ->
+        childFactory(
+            configuration,
+            DefaultAppComponentContext(
+                componentContext = componentContext,
+                bundleId,
+                settings,
+                boarding
+            )
+        )
+    }
+
+inline fun <reified C : Parcelable, T : Any> AppComponentContext.appChildStack(
+    source: OverlayNavigationSource<C>,
+    noinline  initialConfiguration: () -> C?,
+    key: String = "DefaultOverlay",
+    handleBackButton: Boolean = false,
+    persistent: Boolean = false,
+    noinline childFactory: (configuration: C, AppComponentContext) -> T
+): Value<ChildOverlay<C, T>> =
+    appChildOverlay(
+        source = source,
+        initialConfiguration = initialConfiguration,
+        configurationClass = C::class,
+        key = key,
+        handleBackButton = handleBackButton,
+        persistent = persistent,
+        childFactory = childFactory,
+    )
+```
+
+Finally, in your components you can create the new extension function that will utilize the new custom `AppComponentContext`.
+
+```kotlin
+class MyComponent(componentContext: AppComponentContext) : AppComponentContext by componentContext {
+
+    private val navigation = OverlayNavigation<Configuration>()
+
+    private val childStack = appChildOverlay(
+        source = navigation,
+        persistent = false,
+        handleBackButton = true,
+        childFactory = { configuration, appComponentContext -> {
+            // return child components using the custom component context
+        }
+    )
+}
+```

--- a/docs/navigation/stack/component-context.md
+++ b/docs/navigation/stack/component-context.md
@@ -1,0 +1,61 @@
+# How to initialize Child Stack with custom ComponentContext 
+
+In order to pass this `AppComponentContext` to child components, make an extension function on the `AppComponentContext` interface. This custom extension function will initialize the `Child Stack` and provide child `AppComponentContext`.
+
+```kotlin
+fun <C : Parcelable, T : Any> AppComponentContext.appChildStack(
+    source: StackNavigationSource<C>,
+    initialStack: () -> List<C>,
+    configurationClass: KClass<out C>,
+    key: String = "DefaultStack",
+    handleBackButton: Boolean = false,
+    childFactory: (configuration: C, AppComponentContext) -> T
+): Value<ChildStack<C, T>> =
+    childStack(
+        source = source,
+        initialStack = initialStack,
+        configurationClass = configurationClass,
+        key = key,
+        handleBackButton = handleBackButton
+    ) { configuration, componentContext ->
+        childFactory(
+            configuration,
+            DefaultAppComponentContext(
+                componentContext = componentContext
+            )
+        )
+    }
+
+inline fun <reified C : Parcelable, T : Any> AppComponentContext.appChildStack(
+    source: StackNavigationSource<C>,
+    noinline initialStack: () -> List<C>,
+    key: String = "DefaultStack",
+    handleBackButton: Boolean = false,
+    noinline childFactory: (configuration: C, AppComponentContext) -> T
+): Value<ChildStack<C, T>> =
+    appChildStack(
+        source = source,
+        initialStack = initialStack,
+        configurationClass = C::class,
+        key = key,
+        handleBackButton = handleBackButton,
+        childFactory = childFactory,
+    )
+```
+
+Finally, in your components you can create the new extension function that will utilize the new custom `AppComponentContext`.
+
+```kotlin
+class MyComponent(componentContext: AppComponentContext) : AppComponentContext by componentContext {
+
+    private val navigation = StackNavigation<Configuration>()
+
+    private val childStack = appChildStack(
+        source = navigation,
+        initialStack = { listOf(Configuration.Home) },
+        childFactory = { configuration, appComponentContext ->
+            // return child components using the custom component context
+        }
+    )
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,9 +37,11 @@ nav:
       - Navigation: navigation/stack/navigation.md
       - Deep linking: navigation/stack/deeplinking.md
       - Web browser history: navigation/stack/browser-history.md
+      - Custom ComponentContext: navigation/stack/component-context.md
     - Child Overlay:
       - Overview: navigation/overlay/overview.md
       - Navigation: navigation/overlay/navigation.md
+      - Custom ComponentContext: navigation/overlay/component-context.md
 
   - Extensions:
     - Overview: extensions/overview.md


### PR DESCRIPTION
@arkivanov I have reorder a bit the location of the guidelines. Let me know if is not suitable. 

I found it more easy to look for Child Stack and Child Overlay usage with custom component context in respective pages rather than in the custom component page. But I left backlinks to be sure.