### PR TITLE
[compose-darwin] Enable simulatorArm64 target for Compose extensions

### DIFF
--- a/extensions-compose-jetbrains/build.gradle.kts
+++ b/extensions-compose-jetbrains/build.gradle.kts
@@ -17,7 +17,7 @@ setupMultiplatform {
     android()
     jvm()
     macosCompat()
-    iosCompat(simulatorArm64 = null)
+    iosCompat()
 }
 
 setupPublication()

--- a/sample/shared/compose/build.gradle.kts
+++ b/sample/shared/compose/build.gradle.kts
@@ -14,9 +14,7 @@ plugins {
 setupMultiplatform {
     android()
     jvm()
-    iosCompat(
-        simulatorArm64 = null, // Not supported by Compose yet
-    )
+    iosCompat()
 }
 
 kotlin {

--- a/sample/shared/dynamic-features/compose-api/build.gradle.kts
+++ b/sample/shared/dynamic-features/compose-api/build.gradle.kts
@@ -12,9 +12,7 @@ plugins {
 setupMultiplatform {
     android()
     jvm()
-    iosCompat(
-        simulatorArm64 = null, // Not supported by Compose yet
-    )
+    iosCompat()
 }
 
 kotlin {


### PR DESCRIPTION
This PR is for `compose-darwin` branch.

Closes #240.
As part of #74 .