### PR TITLE
Moved sample dialog to CounterComponent

### DIFF
--- a/sample/app-ios/app-ios/CounterView.swift
+++ b/sample/app-ios/app-ios/CounterView.swift
@@ -54,6 +54,10 @@ class PreviewCounterComponent : CounterComponent {
         )
     )
     
+    let dialogOverlay: Value<ChildOverlay<AnyObject, DialogComponent>> =
+        mutableValue(ChildOverlay(overlay: nil))
+    
+    func onInfoClicked() {}
     func onNextClicked() {}
     func onPrevClicked() {}
 }

--- a/sample/app-ios/app-ios/RootView.swift
+++ b/sample/app-ios/app-ios/RootView.swift
@@ -74,12 +74,8 @@ class PreviewRootComponent : RootComponent {
     let childStack: Value<ChildStack<AnyObject, RootComponentChild>> =
         simpleChildStack(RootComponentChild.CountersChild(component: PreviewCountersComponent()))
 
-    let dialog: Value<ChildOverlay<AnyObject, DialogComponent>> =
-        mutableValue(ChildOverlay(overlay: nil))
-
     func onCountersTabClicked() {}
     func onMultiPaneTabClicked() {}
     func onDynamicFeaturesTabClicked() {}
     func onCustomNavigationTabClicked() {}
-    func onInfoActionClicked() {}
 }

--- a/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/counters/counter/CounterContent.kt
+++ b/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/counters/counter/CounterContent.kt
@@ -3,8 +3,9 @@ package com.arkivanov.sample.shared.counters.counter
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
@@ -16,9 +17,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
+import com.arkivanov.decompose.router.overlay.ChildOverlay
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.sample.shared.counters.counter.CounterComponent.Model
+import com.arkivanov.sample.shared.dialog.DialogComponent
+import com.arkivanov.sample.shared.dialog.DialogContent
 
 @Composable
 internal fun CounterContent(component: CounterComponent, modifier: Modifier = Modifier) {
@@ -28,15 +32,22 @@ internal fun CounterContent(component: CounterComponent, modifier: Modifier = Mo
         modifier = modifier
             .border(BorderStroke(width = 1.dp, color = Color.Black))
             .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = model.title,
-            style = MaterialTheme.typography.h6,
+            style = MaterialTheme.typography.h5,
         )
 
+        Spacer(modifier = Modifier.height(8.dp))
+
         Text(text = model.text)
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(onClick = component::onInfoClicked) {
+            Text(text = "Info")
+        }
 
         Button(onClick = component::onNextClicked) {
             Text(text = "Next")
@@ -48,6 +59,11 @@ internal fun CounterContent(component: CounterComponent, modifier: Modifier = Mo
         ) {
             Text(text = "Prev")
         }
+    }
+
+    val dialogOverlay by component.dialogOverlay.subscribeAsState()
+    dialogOverlay.overlay?.instance?.also {
+        DialogContent(dialogComponent = it)
     }
 }
 
@@ -67,6 +83,10 @@ internal class PreviewCounterComponent : CounterComponent {
             )
         )
 
+    override val dialogOverlay: Value<ChildOverlay<*, DialogComponent>> =
+        MutableValue(ChildOverlay<Unit, DialogComponent>())
+
     override fun onNextClicked() {}
     override fun onPrevClicked() {}
+    override fun onInfoClicked() {}
 }

--- a/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/dialog/DialogContent.kt
+++ b/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/dialog/DialogContent.kt
@@ -17,7 +17,7 @@ fun DialogContent(dialogComponent: DialogComponent) {
             dialogComponent.onDismissClicked()
         },
         title = {
-            Text(text = "Decompose Sample Dialog")
+            Text(text = dialogComponent.title)
         },
         text = {
             Text(text = dialogComponent.message)

--- a/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/root/RootContent.kt
+++ b/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/root/RootContent.kt
@@ -7,12 +7,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Refresh
@@ -28,7 +25,6 @@ import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.isEn
 import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.slide
 import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.stackAnimation
 import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
-import com.arkivanov.decompose.router.overlay.ChildOverlay
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
@@ -36,8 +32,6 @@ import com.arkivanov.sample.shared.counters.CountersContent
 import com.arkivanov.sample.shared.counters.PreviewCountersComponent
 import com.arkivanov.sample.shared.customnavigation.CustomNavigationComponent
 import com.arkivanov.sample.shared.customnavigation.CustomNavigationContent
-import com.arkivanov.sample.shared.dialog.DialogComponent
-import com.arkivanov.sample.shared.dialog.DialogContent
 import com.arkivanov.sample.shared.dynamicfeatures.DynamicFeaturesContent
 import com.arkivanov.sample.shared.multipane.MultiPaneContent
 import com.arkivanov.sample.shared.root.RootComponent.Child
@@ -53,14 +47,6 @@ fun RootContent(component: RootComponent, modifier: Modifier = Modifier) {
     val activeComponent = childStack.active.instance
 
     Column(modifier = modifier) {
-        TopAppBar(
-            title = { Text(text = "Decompose Sample") },
-            actions = {
-                IconButton(onClick = { component.onInfoActionClicked() }) {
-                    Icon(Icons.Filled.Info, contentDescription = "Show Application Info")
-                }
-            }
-        )
         Children(
             stack = childStack,
             modifier = Modifier.weight(weight = 1F),
@@ -123,11 +109,6 @@ fun RootContent(component: RootComponent, modifier: Modifier = Modifier) {
                 label = { Text(text = "Custom Nav", softWrap = false) },
             )
         }
-
-        val dialogOverlay by component.dialog.subscribeAsState()
-        dialogOverlay.overlay?.instance?.also {
-            DialogContent(dialogComponent = it)
-        }
     }
 }
 
@@ -183,14 +164,9 @@ internal class PreviewRootComponent : RootComponent {
                 instance = CountersChild(component = PreviewCountersComponent()),
             )
         )
-    override val dialog: Value<ChildOverlay<*, DialogComponent>> =
-        MutableValue(
-            ChildOverlay<Unit, DialogComponent>()
-        )
 
     override fun onCountersTabClicked() {}
     override fun onMultiPaneTabClicked() {}
     override fun onDynamicFeaturesTabClicked() {}
     override fun onCustomNavigationTabClicked() {}
-    override fun onInfoActionClicked() {}
 }

--- a/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/counters/counter/CounterComponent.kt
+++ b/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/counters/counter/CounterComponent.kt
@@ -1,10 +1,15 @@
 package com.arkivanov.sample.shared.counters.counter
 
+import com.arkivanov.decompose.router.overlay.ChildOverlay
 import com.arkivanov.decompose.value.Value
+import com.arkivanov.sample.shared.dialog.DialogComponent
 
 interface CounterComponent {
 
     val model: Value<Model>
+    val dialogOverlay: Value<ChildOverlay<*, DialogComponent>>
+
+    fun onInfoClicked()
 
     fun onNextClicked()
 

--- a/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/root/DefaultRootComponent.kt
+++ b/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/root/DefaultRootComponent.kt
@@ -2,14 +2,8 @@ package com.arkivanov.sample.shared.root
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.ExperimentalDecomposeApi
-import com.arkivanov.decompose.router.overlay.ChildOverlay
-import com.arkivanov.decompose.router.overlay.OverlayNavigation
-import com.arkivanov.decompose.router.overlay.activate
-import com.arkivanov.decompose.router.overlay.childOverlay
-import com.arkivanov.decompose.router.overlay.dismiss
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.router.stack.StackNavigation
-import com.arkivanov.decompose.router.stack.active
 import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.webhistory.WebHistoryController
@@ -18,8 +12,6 @@ import com.arkivanov.essenty.parcelable.Parcelable
 import com.arkivanov.essenty.parcelable.Parcelize
 import com.arkivanov.sample.shared.counters.DefaultCountersComponent
 import com.arkivanov.sample.shared.customnavigation.DefaultCustomNavigationComponent
-import com.arkivanov.sample.shared.dialog.DefaultDialogComponent
-import com.arkivanov.sample.shared.dialog.DialogComponent
 import com.arkivanov.sample.shared.dynamicfeatures.DefaultDynamicFeaturesComponent
 import com.arkivanov.sample.shared.dynamicfeatures.dynamicfeature.FeatureInstaller
 import com.arkivanov.sample.shared.multipane.DefaultMultiPaneComponent
@@ -39,8 +31,6 @@ class DefaultRootComponent constructor(
 
     private val navigation = StackNavigation<Config>()
 
-    private val dialogNavigation = OverlayNavigation<DialogConfig>()
-
     private val stack =
         childStack(
             source = navigation,
@@ -49,38 +39,6 @@ class DefaultRootComponent constructor(
         )
 
     override val childStack: Value<ChildStack<*, Child>> = stack
-
-    private val _dialog =
-        childOverlay(
-            source = dialogNavigation,
-            persistent = false,
-            handleBackButton = true,
-        ) { config, _ ->
-            DefaultDialogComponent(
-                title = config.title,
-                message = config.message,
-                onDismissed = dialogNavigation::dismiss,
-            )
-        }
-
-    override val dialog: Value<ChildOverlay<*, DialogComponent>> = _dialog
-
-    override fun onInfoActionClicked() {
-        val message =
-            when (stack.active.configuration) {
-                Config.Counters -> "You currently on Counters Tab"
-                Config.MultiPane -> "You currently on Multi-Pane Tab"
-                Config.DynamicFeatures -> "You are currently on Dyn Features Tab"
-                Config.CustomNavigation -> "You are currently on Custom Nav Tab"
-            }
-
-        dialogNavigation.activate(
-            DialogConfig(
-                title = "Decompose Sample",
-                message = message,
-            )
-        )
-    }
 
     init {
         webHistoryController?.attach(
@@ -158,12 +116,6 @@ class DefaultRootComponent constructor(
         @Parcelize
         object CustomNavigation : Config
     }
-
-    @Parcelize
-    private data class DialogConfig(
-        val title: String,
-        val message: String,
-    ) : Parcelable
 
     sealed interface DeepLink {
         object None : DeepLink

--- a/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/root/RootComponent.kt
+++ b/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/root/RootComponent.kt
@@ -1,24 +1,20 @@
 package com.arkivanov.sample.shared.root
 
-import com.arkivanov.decompose.router.overlay.ChildOverlay
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.sample.shared.counters.CountersComponent
 import com.arkivanov.sample.shared.customnavigation.CustomNavigationComponent
-import com.arkivanov.sample.shared.dialog.DialogComponent
 import com.arkivanov.sample.shared.dynamicfeatures.DynamicFeaturesComponent
 import com.arkivanov.sample.shared.multipane.MultiPaneComponent
 
 interface RootComponent {
 
     val childStack: Value<ChildStack<*, Child>>
-    val dialog: Value<ChildOverlay<*, DialogComponent>>
 
     fun onCountersTabClicked()
     fun onMultiPaneTabClicked()
     fun onDynamicFeaturesTabClicked()
     fun onCustomNavigationTabClicked()
-    fun onInfoActionClicked()
 
     sealed class Child {
         class CountersChild(val component: CountersComponent) : Child()

--- a/sample/shared/shared/src/jsMain/kotlin/com/arkivanov/sample/shared/counters/counter/CounterContent.kt
+++ b/sample/shared/shared/src/jsMain/kotlin/com/arkivanov/sample/shared/counters/counter/CounterContent.kt
@@ -1,6 +1,8 @@
 package com.arkivanov.sample.shared.counters.counter
 
 import com.arkivanov.sample.shared.RProps
+import com.arkivanov.sample.shared.componentContent
+import com.arkivanov.sample.shared.dialog.DialogComponentContent
 import com.arkivanov.sample.shared.useAsState
 import csstype.AlignItems
 import csstype.BoxSizing
@@ -41,6 +43,14 @@ internal val CounterContent: FC<RProps<CounterComponent>> = FC { props ->
             Button {
                 variant = ButtonVariant.contained
                 color = ButtonColor.primary
+                onClick = { props.component.onInfoClicked() }
+
+                +"Info"
+            }
+
+            Button {
+                variant = ButtonVariant.contained
+                color = ButtonColor.primary
                 onClick = { props.component.onNextClicked() }
 
                 +"Next"
@@ -54,5 +64,10 @@ internal val CounterContent: FC<RProps<CounterComponent>> = FC { props ->
                 +"Prev"
             }
         }
+    }
+
+    val dialogOverlay by props.component.dialogOverlay.useAsState()
+    dialogOverlay.overlay?.instance?.also { dialog ->
+        componentContent(component = dialog, content = DialogComponentContent)
     }
 }

--- a/sample/shared/shared/src/jsMain/kotlin/com/arkivanov/sample/shared/root/RootContent.kt
+++ b/sample/shared/shared/src/jsMain/kotlin/com/arkivanov/sample/shared/root/RootContent.kt
@@ -3,7 +3,6 @@ package com.arkivanov.sample.shared.root
 import com.arkivanov.sample.shared.RProps
 import com.arkivanov.sample.shared.componentContent
 import com.arkivanov.sample.shared.counters.CountersContent
-import com.arkivanov.sample.shared.dialog.DialogComponentContent
 import com.arkivanov.sample.shared.dynamicfeatures.DynamicFeaturesContent
 import com.arkivanov.sample.shared.multipane.MultiPaneContent
 import com.arkivanov.sample.shared.root.RootComponent.Child.CountersChild
@@ -20,29 +19,14 @@ import csstype.Position
 import csstype.number
 import csstype.pct
 import csstype.px
-import mui.material.AppBar
-import mui.material.AppBarPosition
 import mui.material.BottomNavigation
 import mui.material.BottomNavigationAction
 import mui.material.Box
-import mui.material.Button
-import mui.material.Dialog
-import mui.material.DialogActions
-import mui.material.DialogContent
-import mui.material.DialogContentText
-import mui.material.DialogTitle
 import mui.material.Icon
-import mui.material.IconButton
-import mui.material.IconButtonColor
-import mui.material.Size
-import mui.material.Toolbar
-import mui.material.Typography
 import mui.system.sx
 import react.FC
 import react.ReactNode
 import react.create
-import react.dom.aria.ariaDescribedBy
-import react.dom.aria.ariaLabelledBy
 
 var RootContent: FC<RProps<RootComponent>> = FC { props ->
     val childStack by props.component.childStack.useAsState()
@@ -57,32 +41,6 @@ var RootContent: FC<RProps<RootComponent>> = FC { props ->
             bottom = 0.px
             left = 0.px
             right = 0.px
-        }
-
-        AppBar {
-            position = AppBarPosition.static
-
-            Toolbar {
-                Typography {
-                    sx {
-                        flexGrow = number(1.0)
-                    }
-
-                    variant = "h6"
-
-                    +"Decompose Sample"
-                }
-
-                IconButton {
-                    size = Size.large
-                    color = IconButtonColor.inherit
-                    onClick = { props.component.onInfoActionClicked() }
-
-                    Icon {
-                        +"info"
-                    }
-                }
-            }
         }
 
         Box {
@@ -149,11 +107,6 @@ var RootContent: FC<RProps<RootComponent>> = FC { props ->
                 icon = Icon.create { +"location_on" }
             }
         }
-    }
-
-    val dialogOverlay by props.component.dialog.useAsState()
-    dialogOverlay.overlay?.instance?.also { dialog ->
-        componentContent(component = dialog, content = DialogComponentContent)
     }
 }
 


### PR DESCRIPTION
Unfortunately, `ArticleDetailsComponent` (the Multi-Pane tab) adds its own toolbar in portrait mode, so there are two toolbars in this case. I had to remove the main toolbar for now and move the dialog to `CounterComponent`. There is now "Info" button inside `CounterComponent` that shows the current counter value.

This is a follow-up to #255.