### PR TITLE
Fixed custom navigation example

### DIFF
--- a/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/customnavigation/DefaultCustomNavigationComponent.kt
+++ b/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/customnavigation/DefaultCustomNavigationComponent.kt
@@ -76,7 +76,8 @@ class DefaultCustomNavigationComponent(
 
     override fun onBackwardClicked() {
         navigation.navigate { state ->
-            state.copy(index = (state.index - 1) % state.configurations.size)
+            val size = state.configurations.size
+            state.copy(index = (size + state.index - 1) % size)
         }
     }
 


### PR DESCRIPTION
`onBackwardClicked` in [DefaultCustomNavigationComponent.kt](https://github.com/arkivanov/Decompose/compare/master...ttypic:ttypic/fix-custom-navigation?expand=1#diff-84dc9e01cfebbe48e07f552f90f95128812ea0e23d8475fc6967e4f089fa342d) led to negative index and all components stayed in `INACTIVE` status