### PR TITLE
Add integration with iOS in quick start docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -76,3 +76,62 @@ The `extensions-android` module provides extensions to connect Android views bas
     implementation("com.arkivanov.decompose:extensions-android:<version>")
     ```
 
+## Exporting Decompose to iOS Framework
+
+For using Decompose on your iOS project you need to export it to the iOS Framework.
+
+### Regular Framework
+
+
+``` kotlin
+...
+kotlin {
+    ...
+    targets
+        .filterIsInstance<KotlinNativeTarget>()
+        .filter { it.konanTarget.family == Family.IOS }
+        .forEach {
+            it.binaries.framework {
+                ...
+                
+                export("com.arkivanov.decompose:decompose:<version>")
+                export("com.arkivanov.essenty:lifecycle:<essenty_version>")
+    
+                // Optional, only if you need state preservation on Darwin (Apple) targets
+                export("com.arkivanov.essenty:state-keeper:<essenty_version>")
+    
+                // Optional, only if you need state preservation on Darwin (Apple) targets
+                export("com.arkivanov.parcelize.darwin:runtime:<parcelize_darwin_version>")
+            }
+        }
+    ...
+}
+...
+```
+
+### CocoaPods
+
+``` kotlin
+...
+kotlin {
+    ...
+    cocoapods {
+        ...
+        framework {
+            ...
+
+            export("com.arkivanov.decompose:decompose:<version>")
+            export("com.arkivanov.essenty:lifecycle:<essenty_version>")
+
+            // Optional, only if you need state preservation on Darwin (Apple) targets
+            export("com.arkivanov.essenty:state-keeper:<essenty_version>")
+
+            // Optional, only if you need state preservation on Darwin (Apple) targets
+            export("com.arkivanov.parcelize.darwin:runtime:<parcelize_darwin_version>")
+        }
+    }
+    ...
+}
+...
+```
+

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -212,7 +212,7 @@ struct RootView: View {
 
 Please refer to [samples](/Decompose/samples/) for integrations with other UI frameworks.
 
-## Initialising a root component
+## Initializing a root component
 
 ### Android with Jetpack Compose
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -278,7 +278,7 @@ fun main() {
 
 ### IOS with SwiftUI
 
-1. Create `RootHolder` class that holds the root component and its lifecycle. Use `@ObservedObject` property wrapper to observe the root component state.
+1. Create `RootHolder` class that holds the root component and its lifecycle.
 
 ```swift
 class RootHolder : ObservableObject {
@@ -336,9 +336,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         }
     }
     
-    fileprivate func getRootHolder() -> RootHolder {
+    func getRootHolder() -> RootHolder {
         if (rootHolder == nil) {
-            // Create the root component if it was not restored from the saved state
+            // Create new root holder instance if it was not restored from the saved state
             rootHolder = RootHolder(savedState: nil)
         }
         


### PR DESCRIPTION
- Add Child Stack implementation with SwiftUI in start docs
- Add how to initialize root component in iOS project
- Add how to export the necessary dependencies to iOS Framework to work with Decompose inside the iOS project

As part of #362 