### PR TITLE
Fix broken links in the documentation

### DIFF
--- a/docs/component/lifecycle.md
+++ b/docs/component/lifecycle.md
@@ -44,4 +44,4 @@ class SomeComponent(
 
 ## Managing the root lifecycle
 
-When creating a root component, it's required to supply the root lifecycle (see the [docs](../overview/#root-componentcontext) for more information about the root `ComponentContext`). The way how the root lifecycle is controlled depends on the platform. See [Quick Start](../getting-started/quick-start) docs for details and examples.
+When creating a root component, it's required to supply the root lifecycle (see the [docs](../overview/#root-componentcontext) for more information about the root `ComponentContext`). The way how the root lifecycle is controlled depends on the platform. See [Quick Start](../../getting-started/quick-start) docs for details and examples.

--- a/docs/extensions/compose.md
+++ b/docs/extensions/compose.md
@@ -142,7 +142,7 @@ fun DetailsContent(component: DetailsComponent) {
 
 ### Animations
 
-Decompose provides [Child Animation API](https://github.com/arkivanov/Decompose/tree/master/extensions-compose-jetpack/src/main/java/com/arkivanov/decompose/extensions/compose/jetpack/animation/child) for Compose, as well as some predefined animation specs. To enable child animations you need to pass the `animation` argument to the `Children` function. There are predefined animators provided by Decompose.
+Decompose provides [Child Animation API](https://github.com/arkivanov/Decompose/tree/master/extensions-compose-jetpack/src/main/java/com/arkivanov/decompose/extensions/compose/jetpack/stack/animation) for Compose, as well as some predefined animation specs. To enable child animations you need to pass the `animation` argument to the `Children` function. There are predefined animators provided by Decompose.
 
 #### Fade animation
 

--- a/docs/navigation/stack/deeplinking.md
+++ b/docs/navigation/stack/deeplinking.md
@@ -9,7 +9,7 @@ documentation. For example here is the [related documentation](https://developer
 
 ### Handling deep links
 
-Given the basic example from the [Child Stack overview](overview) page, we can easily handle deep
+Given the basic example from the [Child Stack overview](../overview) page, we can easily handle deep
 links. Let's say we have a link like `http://myitems.com?itemId=3`. When the user clicks on it, we want to open the details screen of the
 item with the provided `id`. When the user closes the details screen, they should be navigated back to the list screen. The idea is to pass
 parsed data from the deep link to a component responsible for navigation, in our case it is the `Root` component.

--- a/docs/navigation/stack/navigation.md
+++ b/docs/navigation/stack/navigation.md
@@ -26,7 +26,7 @@ The `Child Stack` usually performs the navigation synchronously, which means tha
 
 ## StackNavigator extension functions
 
-There are `StackNavigator` [extension functions](https://github.com/arkivanov/Decompose/blob/master/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/StackNavigatorExt.kt) to simplify the navigation. Some of which were already used in the [Child Stack overview example](overview#routing-example).
+There are `StackNavigator` [extension functions](https://github.com/arkivanov/Decompose/blob/master/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/StackNavigatorExt.kt) to simplify the navigation. Some of which were already used in the [Child Stack overview example](../overview#example).
 
 The preceding examples will utilize the following `sealed class` & `navigation` for showcasing the usage of the `StackNavigator` extensions.
 
@@ -79,7 +79,7 @@ Drops the configurations at the top of the stack while the provided predicate re
 navigation.popWhile { topOfStack: Configuration -> topOfStack !is B }
 ```
 
-![](Decompose/media/RouterPopWhile.png)
+![](../../media/RouterPopWhile.png)
 
 ### replaceCurrent
 
@@ -93,7 +93,7 @@ navigation.replaceCurrent(Configuration.D)
 
 ### bringToFront
 
-Removes all components with configurations of the provided `Configuration`'s class, and adds the provided `Configuration` to the top of the stack. This is primarily helpful when implementing a Decompose app with [bottom navigation](https://github.com/arkivanov/Decompose/discussions/178)
+Removes all components with configurations of the provided `Configuration`'s class, and adds the provided `Configuration` to the top of the stack. This is primarily helpful when implementing a Decompose app with [bottom navigation](https://github.com/badoo/Decompose/discussions/178)
 
 !!! note
     The operation is performed as one transaction. If there is already a component with the same configuration, it will not be recreated.

--- a/docs/navigation/stack/navigation.md
+++ b/docs/navigation/stack/navigation.md
@@ -93,7 +93,7 @@ navigation.replaceCurrent(Configuration.D)
 
 ### bringToFront
 
-Removes all components with configurations of the provided `Configuration`'s class, and adds the provided `Configuration` to the top of the stack. This is primarily helpful when implementing a Decompose app with [bottom navigation](https://github.com/badoo/Decompose/discussions/178)
+Removes all components with configurations of the provided `Configuration`'s class, and adds the provided `Configuration` to the top of the stack. This is primarily helpful when implementing a Decompose app with Bottom Navigation. See the [related discussion](https://github.com/badoo/Decompose/discussions/178) in the *old repository*.
 
 !!! note
     The operation is performed as one transaction. If there is already a component with the same configuration, it will not be recreated.


### PR DESCRIPTION
The [Documentation](https://arkivanov.github.io/Decompose/) has several broken links that occurred after changes made since version 0.8.0. When a reader clicks on such a link, they will see an error (404).

To be more specific, the following broken links are present in the documentation:
- The [Lifecycle component](https://arkivanov.github.io/Decompose/component/lifecycle/) page has a broken link to the [Quick start](https://arkivanov.github.io/Decompose/getting-started/quick-start/) guide.
- The [Deep linking](https://arkivanov.github.io/Decompose/navigation/stack/deeplinking/) page has a broken link to the [Child Stack overview](https://arkivanov.github.io/Decompose/navigation/stack/overview/).
- The [Navigation with Child Stack](https://arkivanov.github.io/Decompose/navigation/stack/navigation/) page has broken links to the following:  
   - [Child Stack overview example](https://arkivanov.github.io/Decompose/navigation/stack/overview/#example)
   - popWhile [image](https://arkivanov.github.io/Decompose/media/RouterPopWhile.png)
   - [Bottom navigation discussion](https://github.com/badoo/Decompose/discussions/178)
- [Extensions for Jetpack/JetBrains Compose](https://arkivanov.github.io/Decompose/extensions/compose/) page has a broken link to the [Child Animation API](https://github.com/arkivanov/Decompose/tree/master/extensions-compose-jetpack/src/main/java/com/arkivanov/decompose/extensions/compose/jetpack/stack/animation).