### PR TITLE
Fix StackView Decompose Helper for iOS

### DIFF
--- a/sample/app-ios/app-ios/DecomposeHelpers/StackView.swift
+++ b/sample/app-ios/app-ios/DecomposeHelpers/StackView.swift
@@ -17,7 +17,16 @@ struct StackView<T: AnyObject, Content: View>: View {
     var body: some View {
         // iOS 16.0 has an issue with swipe back see https://stackoverflow.com/questions/73978107/incomplete-swipe-back-gesture-causes-navigationpath-mismanagement
         if #available(iOS 16.1, *) {
-            NavigationStack(path: Binding(get: { stack.dropFirst() }, set: { _ in onBack() })) {
+            NavigationStack(
+                path: Binding(
+                    get: { stack.dropFirst() },
+                    set: { updatedPath in
+                        while stack.count > updatedPath.count + 1 {
+                            onBack()
+                        }
+                    }
+                )
+            ) {
                 childContent(stack.first!.instance!)
                     .navigationDestination(for: Child<AnyObject, T>.self) {
                         childContent($0.instance!)


### PR DESCRIPTION
Correct behavior when user was trying to pop more than one view at once.

[Incorrect behavior example](https://github.com/arkivanov/Decompose/assets/483899/4441b075-153c-4983-bf9c-da1585581828).

[After the fix](https://github.com/arkivanov/Decompose/assets/483899/68cc396f-1079-4497-bd4c-674ae15d8261).

