### PR TITLE
Fixed MergedLifecycle not destroyed when one lifecycle is destroyed before another is created

### DIFF
--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/lifecycle/MergedLifecycle.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/lifecycle/MergedLifecycle.kt
@@ -3,7 +3,13 @@ package com.arkivanov.decompose.lifecycle
 import com.arkivanov.decompose.InternalDecomposeApi
 import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.create
+import com.arkivanov.essenty.lifecycle.destroy
 import com.arkivanov.essenty.lifecycle.doOnDestroy
+import com.arkivanov.essenty.lifecycle.pause
+import com.arkivanov.essenty.lifecycle.resume
+import com.arkivanov.essenty.lifecycle.start
+import com.arkivanov.essenty.lifecycle.stop
 
 @InternalDecomposeApi
 class MergedLifecycle private constructor(
@@ -15,14 +21,11 @@ class MergedLifecycle private constructor(
     constructor(lifecycle1: Lifecycle, lifecycle2: Lifecycle) : this(LifecycleRegistry(), lifecycle1, lifecycle2)
 
     init {
-        if ((lifecycle1.state == Lifecycle.State.DESTROYED) || (lifecycle2.state == Lifecycle.State.DESTROYED)) {
-            registry.onCreate()
-            registry.onDestroy()
-        } else {
-            var state1: Lifecycle.State = Lifecycle.State.INITIALIZED
-            var state2: Lifecycle.State = Lifecycle.State.INITIALIZED
-            val observer1 = CallbacksImpl(registry = registry, setState = { state1 = it }, getOtherState = { state2 })
-            val observer2 = CallbacksImpl(registry = registry, setState = { state2 = it }, getOtherState = { state1 })
+        moveTo(minOf(lifecycle1.state, lifecycle2.state))
+
+        if ((lifecycle1.state != Lifecycle.State.DESTROYED) && (lifecycle2.state != Lifecycle.State.DESTROYED)) {
+            val observer1 = CallbacksImpl { state -> moveTo(minOf(state, lifecycle2.state)) }
+            val observer2 = CallbacksImpl { state -> moveTo(minOf(state, lifecycle1.state)) }
 
             lifecycle1.subscribe(observer1)
             lifecycle2.subscribe(observer2)
@@ -34,47 +37,91 @@ class MergedLifecycle private constructor(
         }
     }
 
+    private fun moveTo(state: Lifecycle.State) {
+        when (state) {
+            Lifecycle.State.DESTROYED -> moveToDestroyed()
+            Lifecycle.State.INITIALIZED -> Unit
+            Lifecycle.State.CREATED -> moveToCreated()
+            Lifecycle.State.STARTED -> moveToStarted()
+            Lifecycle.State.RESUMED -> moveToResumed()
+        }
+    }
+
+    private fun moveToDestroyed() {
+        when (registry.state) {
+            Lifecycle.State.DESTROYED -> Unit
+
+            Lifecycle.State.INITIALIZED -> {
+                registry.create()
+                registry.destroy()
+            }
+
+            Lifecycle.State.CREATED,
+            Lifecycle.State.STARTED,
+            Lifecycle.State.RESUMED -> registry.destroy()
+        }
+    }
+
+    private fun moveToCreated() {
+        when (registry.state) {
+            Lifecycle.State.DESTROYED -> Unit
+            Lifecycle.State.INITIALIZED -> registry.create()
+
+            Lifecycle.State.CREATED -> Unit
+
+            Lifecycle.State.STARTED,
+            Lifecycle.State.RESUMED -> registry.stop()
+        }
+    }
+
+    private fun moveToStarted() {
+        when (registry.state) {
+            Lifecycle.State.INITIALIZED,
+            Lifecycle.State.CREATED -> registry.start()
+
+            Lifecycle.State.RESUMED -> registry.pause()
+
+            Lifecycle.State.DESTROYED,
+            Lifecycle.State.STARTED -> Unit
+        }
+    }
+
+    private fun moveToResumed() {
+        when (registry.state) {
+            Lifecycle.State.INITIALIZED,
+            Lifecycle.State.CREATED,
+            Lifecycle.State.STARTED -> registry.resume()
+
+            Lifecycle.State.RESUMED,
+            Lifecycle.State.DESTROYED -> Unit
+        }
+    }
+
     private class CallbacksImpl(
-        private val registry: Lifecycle.Callbacks,
-        private val setState: (Lifecycle.State) -> Unit,
-        private val getOtherState: () -> Lifecycle.State,
+        private val onStateChanged: (Lifecycle.State) -> Unit,
     ) : Lifecycle.Callbacks {
         override fun onCreate() {
-            onUp(Lifecycle.State.CREATED, registry::onCreate)
+            onStateChanged(Lifecycle.State.CREATED)
         }
 
         override fun onStart() {
-            onUp(Lifecycle.State.STARTED, registry::onStart)
+            onStateChanged(Lifecycle.State.STARTED)
         }
 
         override fun onResume() {
-            onUp(Lifecycle.State.RESUMED, registry::onResume)
+            onStateChanged(Lifecycle.State.RESUMED)
         }
 
         override fun onPause() {
-            onDown(Lifecycle.State.STARTED, registry::onPause)
+            onStateChanged(Lifecycle.State.STARTED)
         }
 
         override fun onStop() {
-            onDown(Lifecycle.State.CREATED, registry::onStop)
+            onStateChanged(Lifecycle.State.CREATED)
         }
 
         override fun onDestroy() {
-            onDown(Lifecycle.State.INITIALIZED, registry::onDestroy)
-        }
-
-        private fun onUp(state: Lifecycle.State, call: () -> Unit) {
-            setState(state)
-            if (state <= getOtherState()) {
-                call()
-            }
-        }
-
-        private fun onDown(state: Lifecycle.State, call: () -> Unit) {
-            if (state < getOtherState()) {
-                call()
-            }
-            setState(state)
+            onStateChanged(Lifecycle.State.DESTROYED)
         }
     }
 }

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/lifecycle/MergedLifecycleTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/lifecycle/MergedLifecycleTest.kt
@@ -368,6 +368,16 @@ class MergedLifecycleTest {
     }
 
     @Test
+    fun WHEN_lifecycle1_destroyed_and_lifecycle2_destroyed_THEN_onCreate_onDestroy_called() {
+        lifecycle1.create()
+        lifecycle1.destroy()
+        lifecycle2.create()
+        lifecycle2.destroy()
+
+        callbacks.assertEvents(Event.ON_CREATE, Event.ON_DESTROY)
+    }
+
+    @Test
     fun GIVEN_lifecycle1_destroyed_WHEN_MergedLifecycle_created_THEN_not_subscribed() {
         val lifecycle1 = TestLifecycleRegistry()
         val lifecycle2 = TestLifecycleRegistry()
@@ -410,6 +420,16 @@ class MergedLifecycleTest {
         lifecycle2.destroy()
 
         val merged = MergedLifecycle(lifecycle1, lifecycle2)
+
+        assertEquals(Lifecycle.State.DESTROYED, merged.state)
+    }
+
+    @Test
+    fun WHEN_lifecycle1_created_and_destroyed_and_lifecycle2_created_and_destroyed_THEN_state_destroyed() {
+        lifecycle1.create()
+        lifecycle1.destroy()
+        lifecycle2.create()
+        lifecycle2.destroy()
 
         assertEquals(Lifecycle.State.DESTROYED, merged.state)
     }


### PR DESCRIPTION
Fix #393