### PR TITLE
Fix typo in quick-start.md

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -32,7 +32,7 @@ class DefaultRootComponent(
     init {
         lifecycle... // Access the Lifecycle
         stateKeeper... // Access the StateKeeper
-        intanceKeeper... // Access the InstanceKeeper
+        instanceKeeper... // Access the InstanceKeeper
         backHandler... // Access the BackHandler
     }
 }


### PR DESCRIPTION
I spotted this while copy/pasting the example 😬