### PR TITLE
Fix swipeEdges doesn't change across recompositions

### DIFF
--- a/extensions-compose-jetbrains/src/nonAndroidMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/PredictiveBackGestureOverlay.kt
+++ b/extensions-compose-jetbrains/src/nonAndroidMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/PredictiveBackGestureOverlay.kt
@@ -99,7 +99,7 @@ private fun Modifier.handleBackGestures(
     onIconMoved: (position: Offset, progress: Float, BackGestureHandler.Edge) -> Unit,
     onIconHidden: () -> Unit,
 ): Modifier =
-    pointerInput(backDispatcher) {
+    pointerInput(backDispatcher, swipeEdges) {
         awaitEachGesture {
             onIconHidden()
 


### PR DESCRIPTION
This will not work if `isRtl` changes after composition

```kotlin

val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl

PredictiveBackGestureOverlay(
    backDispatcher = backDispatcher,
    backIcon = null,
    modifier = modifier,
    swipeEdges = setOf(
          if (isRtl)
              BackEvent.SwipeEdge.RIGHT
          else BackEvent.SwipeEdge.LEFT
      ),
    ),content = content
)
```