### PR TITLE
Revert "LTR/RTL in PredictiveBackGestureOverlay"

### DIFF
--- a/extensions-compose-jetbrains/api/jvm/extensions-compose-jetbrains.api
+++ b/extensions-compose-jetbrains/api/jvm/extensions-compose-jetbrains.api
@@ -3,7 +3,7 @@ public final class com/arkivanov/decompose/extensions/compose/jetbrains/Predicti
 }
 
 public final class com/arkivanov/decompose/extensions/compose/jetbrains/PredictiveBackGestureOverlayKt {
-	public static final fun PredictiveBackGestureOverlay (Lcom/arkivanov/essenty/backhandler/BackDispatcher;Lkotlin/jvm/functions/Function4;Landroidx/compose/ui/Modifier;ZZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun PredictiveBackGestureOverlay (Lcom/arkivanov/essenty/backhandler/BackDispatcher;Lkotlin/jvm/functions/Function4;Landroidx/compose/ui/Modifier;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/arkivanov/decompose/extensions/compose/jetbrains/SubscribeAsStateKt {


### PR DESCRIPTION
Reverts arkivanov/Decompose#536, as it contains a breaking API change. Will be cherry-picked to v2.2 instead.