### PR TITLE
Updated gradle-setup-plugin plugin, disabled debug artifact publications for Android

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.toString() == "com.arkivanov.gradle.setup") {
-                useModule("com.github.arkivanov:gradle-setup-plugin:655aedff78")
+                useModule("com.github.arkivanov:gradle-setup-plugin:4a116614b3")
             }
         }
     }


### PR DESCRIPTION
As part of https://github.com/arkivanov/gradle-setup-plugin/issues/2