### PR TITLE
Use addObserverForName instead of addObserver in ApplicationLifecycle

### DIFF
--- a/decompose/src/itvosMain/kotlin/com/arkivanov/decompose/lifecycle/ApplicationLifecycle.kt
+++ b/decompose/src/itvosMain/kotlin/com/arkivanov/decompose/lifecycle/ApplicationLifecycle.kt
@@ -3,22 +3,25 @@ package com.arkivanov.decompose.lifecycle
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.create
 import com.arkivanov.essenty.lifecycle.destroy
+import com.arkivanov.essenty.lifecycle.doOnDestroy
 import com.arkivanov.essenty.lifecycle.pause
 import com.arkivanov.essenty.lifecycle.resume
 import com.arkivanov.essenty.lifecycle.start
 import com.arkivanov.essenty.lifecycle.stop
-import kotlinx.cinterop.BetaInteropApi
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.ObjCAction
+import platform.Foundation.NSNotification
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSNotificationName
-import platform.Foundation.NSSelectorFromString
+import platform.Foundation.NSOperationQueue
+import platform.UIKit.UIApplication
 import platform.UIKit.UIApplicationDidBecomeActiveNotification
 import platform.UIKit.UIApplicationDidEnterBackgroundNotification
+import platform.UIKit.UIApplicationState
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
 import platform.UIKit.UIApplicationWillResignActiveNotification
 import platform.UIKit.UIApplicationWillTerminateNotification
+import platform.darwin.NSObjectProtocol
 
 /**
  * An implementation of [Lifecycle] that follows the [UIApplication][platform.UIKit.UIApplication] lifecycle notifications.
@@ -30,55 +33,38 @@ class ApplicationLifecycle private constructor(
 
     constructor() : this(lifecycle = LifecycleRegistry())
 
+    private val willEnterForegroundObserver = addObserver(UIApplicationWillEnterForegroundNotification) { lifecycle.start() }
+    private val didBecomeActiveObserver = addObserver(UIApplicationDidBecomeActiveNotification) { lifecycle.resume() }
+    private val willResignActiveObserver = addObserver(UIApplicationWillResignActiveNotification) { lifecycle.pause() }
+    private val didEnterBackgroundObserver = addObserver(UIApplicationDidEnterBackgroundNotification) { lifecycle.stop() }
+    private val willTerminateObserver = addObserver(UIApplicationWillTerminateNotification) { lifecycle.destroy() }
+
     init {
-        addObserver(name = UIApplicationWillEnterForegroundNotification, selectorName = "willEnterForeground")
-        addObserver(name = UIApplicationDidBecomeActiveNotification, selectorName = "didBecomeActive")
-        addObserver(name = UIApplicationWillResignActiveNotification, selectorName = "willResignActive")
-        addObserver(name = UIApplicationDidEnterBackgroundNotification, selectorName = "didEnterBackground")
-        addObserver(name = UIApplicationWillTerminateNotification, selectorName = "willTerminate")
+        NSOperationQueue.mainQueue.addOperationWithBlock {
+            if (lifecycle.state == Lifecycle.State.INITIALIZED) {
+                when (UIApplication.sharedApplication.applicationState) {
+                    UIApplicationState.UIApplicationStateActive -> lifecycle.resume()
+                    UIApplicationState.UIApplicationStateInactive -> lifecycle.start()
+                    UIApplicationState.UIApplicationStateBackground -> lifecycle.create()
+                    else -> lifecycle.create()
+                }
+            }
+        }
+
+        doOnDestroy {
+            NSNotificationCenter.defaultCenter.removeObserver(willEnterForegroundObserver)
+            NSNotificationCenter.defaultCenter.removeObserver(didBecomeActiveObserver)
+            NSNotificationCenter.defaultCenter.removeObserver(willResignActiveObserver)
+            NSNotificationCenter.defaultCenter.removeObserver(didEnterBackgroundObserver)
+            NSNotificationCenter.defaultCenter.removeObserver(willTerminateObserver)
+        }
     }
 
-    @OptIn(ExperimentalForeignApi::class)
-    private fun addObserver(name: NSNotificationName, selectorName: String) {
-        NSNotificationCenter.defaultCenter.addObserver(
+    private fun addObserver(name: NSNotificationName, block: (NSNotification?) -> Unit): NSObjectProtocol =
+        NSNotificationCenter.defaultCenter.addObserverForName(
             name = name,
             `object` = null,
-            observer = this,
-            selector = NSSelectorFromString(selectorName),
+            queue = NSOperationQueue.mainQueue,
+            usingBlock = block,
         )
-    }
-
-    @Suppress("unused")
-    @OptIn(BetaInteropApi::class)
-    @ObjCAction
-    fun willEnterForeground() {
-        lifecycle.start()
-    }
-
-    @Suppress("unused")
-    @OptIn(BetaInteropApi::class)
-    @ObjCAction
-    fun didBecomeActive() {
-        lifecycle.resume()
-    }
-
-    @Suppress("unused")
-    @OptIn(BetaInteropApi::class)
-    @ObjCAction
-    fun willResignActive() {
-        lifecycle.pause()
-    }
-
-    @Suppress("unused")
-    @OptIn(BetaInteropApi::class)
-    @ObjCAction
-    fun didEnterBackground() {
-        lifecycle.stop()
-    }
-
-    @OptIn(BetaInteropApi::class)
-    @ObjCAction
-    fun willTerminate() {
-        lifecycle.destroy()
-    }
 }


### PR DESCRIPTION
This should fix possible crash in `ApplicationLifecycle`: `unrecognized selector sent to instance`.