### PR TITLE
Fixed the issue of 'HorizontalPager' slow scrolling and 'onPageSelected' not being called.

### DIFF
--- a/extensions-compose-jetbrains/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/pages/Pages.kt
+++ b/extensions-compose-jetbrains/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/pages/Pages.kt
@@ -81,7 +81,7 @@ fun <C : Any, T : Any> Pages(
         }
     }
 
-    DisposableEffect(state.currentPage) {
+    DisposableEffect(state.currentPage, state.targetPage) {
         if (state.currentPage == state.targetPage) {
             onPageSelected(state.currentPage)
         }

--- a/extensions-compose-jetpack/src/main/java/com/arkivanov/decompose/extensions/compose/jetpack/pages/Pages.kt
+++ b/extensions-compose-jetpack/src/main/java/com/arkivanov/decompose/extensions/compose/jetpack/pages/Pages.kt
@@ -81,7 +81,7 @@ fun <C : Any, T : Any> Pages(
         }
     }
 
-    DisposableEffect(state.currentPage) {
+    DisposableEffect(state.currentPage, state.targetPage) {
         if (state.currentPage == state.targetPage) {
             onPageSelected(state.currentPage)
         }


### PR DESCRIPTION
In Compose 1.6.0-beta01, there is an issue on iOS devices where 'onPageSelected' does not get called during slow scrolling. Although this has been fixed on Android, we need to ensure cross-platform compatibility.