### PR TITLE
StackAnimationProvider fix document

### DIFF
--- a/docs/extensions/compose.md
+++ b/docs/extensions/compose.md
@@ -288,7 +288,7 @@ fun App() {
     }
 }
 
-private object DefaultStackAnimationProvider : StackAnimationProvider {
+private val DefaultStackAnimationProvider = object : StackAnimationProvider {
     override fun <C : Any, T : Any> provide(): StackAnimation<C, T> =
         stackAnimation(slide() + scale())
 }


### PR DESCRIPTION
## Document seems like sam interface. But it is not.

<img width="715" alt="image" src="https://github.com/arkivanov/Decompose/assets/147542533/74dc84ef-2c65-48a5-b965-ac78e9dd1dce">


```kotlin
@Composable
fun App() {
    CompositionLocalProvider(LocalStackAnimationProvider provides DefaultStackAnimationProvider) {
        // The rest of the code
    }
}

private object DefaultStackAnimationProvider : StackAnimationProvider {
    override fun <C : Any, T : Any> provide(): StackAnimation<C, T> =
        stackAnimation(slide() + scale())
}
```

## Code
```kotlin
interface StackAnimationProvider {
    fun <C : Any, T : Any> provide(): StackAnimation<C, T>?
}

val LocalStackAnimationProvider = compositionLocalOf<StackAnimationProvider> {
    object : StackAnimationProvider {
        override fun <C : Any, T : Any> provide(): StackAnimation<C, T>? = null
    }
}

```