### PR TITLE
Fixed the issue where 'onPageSelected' was not being called during slow scrolling with 'HorizontalPager'.

### DIFF
--- a/extensions-compose-jetbrains/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/pages/Pages.kt
+++ b/extensions-compose-jetbrains/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/pages/Pages.kt
@@ -81,7 +81,7 @@ fun <C : Any, T : Any> Pages(
         }
     }
 
-    DisposableEffect(state.currentPage) {
+    DisposableEffect(state.currentPage, state.targetPage) {
         if (state.currentPage == state.targetPage) {
             onPageSelected(state.currentPage)
         }

--- a/extensions-compose-jetpack/src/main/java/com/arkivanov/decompose/extensions/compose/jetpack/pages/Pages.kt
+++ b/extensions-compose-jetpack/src/main/java/com/arkivanov/decompose/extensions/compose/jetpack/pages/Pages.kt
@@ -81,7 +81,7 @@ fun <C : Any, T : Any> Pages(
         }
     }
 
-    DisposableEffect(state.currentPage) {
+    DisposableEffect(state.currentPage, state.targetPage) {
         if (state.currentPage == state.targetPage) {
             onPageSelected(state.currentPage)
         }


### PR DESCRIPTION
在 Compose 1.6.0-beta01 中，iOS 设备上存在“onPageSelected”无法显示的问题。在慢速滚动期间不会被调用。虽然Android上已经修复了这个问题，但我们还需要确保跨平台兼容性。

Auto-translate:

> In Compose 1.6.0-beta01, there is an issue where "onPageSelected" is not displayed on iOS devices. Not called during slow scrolling. While this issue has been fixed on Android, we still need to ensure cross-platform compatibility.