### PR TITLE
Updated docs

### DIFF
--- a/docs/component/instance-retaining.md
+++ b/docs/component/instance-retaining.md
@@ -36,6 +36,10 @@ Although discouraged, it is still possible to have all components retained over 
 !!!warning
     Pay attention when supplying dependencies to a retained component to avoid leaking the hosting `Activity` or `Fragment`.
 
+!!! warning
+
+    The `retainedComponent` function must only be called once during the lifetime of the host Activity or Fragment, typically in `onCreate`. Calling it a second time will result in a crash.
+
 ```kotlin
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/docs/component/overview.md
+++ b/docs/component/overview.md
@@ -51,6 +51,10 @@ Decompose provides a few handy [helper functions](https://github.com/arkivanov/D
 
 For this case Decompose provides `defaultComponentContext()` extension function, which can be called in scope of an `Activity`.
 
+!!! warning
+
+    The `defaultComponentContext` function must only be called once during the lifetime of the host Activity or Fragment, typically in `onCreate`. Calling it a second time will result in a crash.
+
 ```kotlin
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -336,6 +336,10 @@ Please refer to [samples](../samples.md) for integrations with other UI framewor
 
 Use `defaultComponentContext` extension function to create the root `ComponentContext` in an `Activity` or a `Fragment`.
 
+!!! warning
+
+    The `defaultComponentContext` function must only be called once during the lifetime of the host Activity or Fragment, typically in `onCreate`. Calling it a second time will result in a crash.
+
 ```kotlin
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
- Added warnings that `defaultComponentContext` and `retainedComponent` may only be called once.
- Described handling deep links on Android.

Closes #596.