### PR TITLE
Fix standard predictive back nagiviation code sample

### DIFF
--- a/docs/extensions/compose.md
+++ b/docs/extensions/compose.md
@@ -578,8 +578,8 @@ fun RootContent(component: RootComponent) {
         stack = component.childStack,
         animation = predictiveBackAnimation(
             backHandler = component.backHandler,
-            animation = stackAnimation(fade() + scale()),
-            selector = selector = { backEvent, _, _ -> androidPredictiveBackAnimatable(backEvent) },
+            fallbackAnimation = stackAnimation(fade() + scale()),
+            selector = { backEvent, _, _ -> androidPredictiveBackAnimatable(backEvent) },
             onBack = component::onBackClicked,
         ),
     ) {


### PR DESCRIPTION
The current code sample contains two mistakes:
1. The `animation` parameter is actually called `fallbackAnimation`.
2. The syntax `selector = selector = ...` looks like a typo.

I went ahead and quickly fixed both of them :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `compose.md` file to rename the `animation` parameter to `fallbackAnimation` in the `RootContent` function, enhancing clarity on its usage in stack animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->