### PR TITLE
Revert "Added main thread check to children function"

### DIFF
--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/children/ChildrenFactory.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/children/ChildrenFactory.kt
@@ -115,8 +115,6 @@ fun <Ctx : GenericComponentContext<Ctx>, C : Any, T : Any, E : Any, N : NavState
     backTransformer: (state: N) -> (() -> N)? = { null },
     childFactory: (configuration: C, componentContext: Ctx) -> T,
 ): Value<S> {
-    checkMainThread()
-
     val mainBackHandler = backHandler.child()
     val relay = Relay<NavEvent<E>>()
     val cancellation = source.subscribe { relay.accept(NavEvent.Event(it)) }


### PR DESCRIPTION
Reverts arkivanov/Decompose#716.
Related to #712.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal control flow by removing unnecessary `checkMainThread()` call in the component creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->