### PR TITLE
Updated docs for Duplicate Configurations feature

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,3 +36,13 @@ This exception is thrown when duplicated component configurations are detected b
 
 - Prefer `pushNew` function instead of `push` when showing a component on a button click, it will properly handle accidental double clicks.
 - Prefer `pushToFront` to prevent duplicated components with the same data (configurations) in the stack.
+
+### The experimental Duplicate Configurations mode
+
+You can also try enabling the experimental Duplicate Configurations mode using the following flag:
+
+```kotlin
+DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+```
+
+This will allow having duplicate configurations in all navigation models. Please keep in mind that this feature is experimental.

--- a/docs/navigation/children/overview.md
+++ b/docs/navigation/children/overview.md
@@ -8,7 +8,7 @@ The navigation is performed by transforming the current `NavState` to a new one.
 
 ## ChildNavState
 
-`ChildNavState` represents a state of a child component. It holds a `Configuration` that works as a key of the child component, and a `Status` that represents the required lifecycle status of the child component. As mentioned earlier, the `Configuration` must unique within the `NavState`.
+`ChildNavState` represents a state of a child component. It holds a `Configuration` that works as a key of the child component, and a `Status` that represents the required lifecycle status of the child component. As mentioned earlier, the `Configuration` must be unique within the `NavState`, unless `DecomposeExperimentFlags.duplicateConfigurationsEnabled` flag is enabled.
 
 The `Status` can be one of the following:
 

--- a/docs/navigation/pages/overview.md
+++ b/docs/navigation/pages/overview.md
@@ -29,6 +29,16 @@ Similarly to `Child Stack`, each component created and managed by the `Child Pag
 
 - Configurations must be unique (by equality) within `Child Pages`.
 
+### The experimental Duplicate Configurations mode
+
+You can also try enabling the experimental Duplicate Configurations mode using the following flag:
+
+```kotlin
+DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+```
+
+This will allow having duplicate configurations in all navigation models. Please keep in mind that this feature is experimental.
+
 ### Initializing Child Pages
 
 There are three steps to initialize `Child Pages`:

--- a/docs/navigation/stack/overview.md
+++ b/docs/navigation/stack/overview.md
@@ -21,6 +21,16 @@ Each component created and managed by the `Child Stack` has a configuration, ple
 
 - Configurations must be unique (by equality) within the `Child Stack`.
 
+### The experimental Duplicate Configurations mode
+
+You can also try enabling the experimental Duplicate Configurations mode using the following flag:
+
+```kotlin
+DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+```
+
+This will allow having duplicate configurations in all navigation models. Please keep in mind that this feature is experimental.
+
 ### Initializing the Child Stack
 
 There are three steps to initialize the `Child Stack`:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added explanations for an experimental mode to handle duplicate configurations in navigation models.
  - Updated details on when `Configuration` needs to be unique within `NavState` based on a new flag.
  - Introduced "Experimental Duplicate Configurations mode" across multiple documentation files, explaining the feature and its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->