### PR TITLE
Updated replaceAll docs

### DIFF
--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/StackNavigatorExt.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/StackNavigatorExt.kt
@@ -151,7 +151,8 @@ inline fun <C : Any> StackNavigator<C>.replaceCurrent(configuration: C, crossinl
 }
 
 /**
- * Replaces the whole stack with the provided [configurations].
+ * Replaces all configurations currently in the stack with the provided [configurations].
+ * Components that remain in the stack are not recreated, components that are no longer in the stack are destroyed.
  *
  * @param onComplete called when the navigation is finished (either synchronously or asynchronously).
  */


### PR DESCRIPTION
Closes #729.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the behavior of the `replaceWholeStack` method in the `StackNavigator` class, specifying that only components no longer in the stack are destroyed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->