### PR TITLE
Force javaTarget 11 for all non-Android JVM targets

### DIFF
--- a/deps.versions.toml
+++ b/deps.versions.toml
@@ -2,7 +2,7 @@
 
 decompose = "3.2.0-alpha03"
 kotlin = "2.0.10"
-essenty = "2.2.0-alpha03"
+essenty = "2.2.0-alpha04"
 reaktive = "1.2.3"
 junit = "4.13.2"
 jetbrainsCompose = "1.7.0-alpha02"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.toString() == "com.arkivanov.gradle.setup") {
-                useModule("com.github.arkivanov:gradle-setup-plugin:310f7f6b99")
+                useModule("com.github.arkivanov:gradle-setup-plugin:8eb6bb973c")
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the version of the gradle-setup-plugin to enhance build performance and stability.
	- Incremented the version of the essenty dependency to introduce potential bug fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->