### PR TITLE
Don't animate the previous child after predictive back gesture finished and stack popped

### DIFF
--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
@@ -57,10 +57,10 @@ internal class DefaultStackAnimation<C : Any, T : Any>(
             currentStack = stack
 
             val updateItems =
-                if (stack.active.key == oldStack.active.key) {
-                    items.keys.singleOrNull() != stack.active.key
-                } else {
-                    items.keys.toList() != stackKeys
+                when {
+                    stack.active.key == oldStack.active.key -> items.keys.singleOrNull() != stack.active.key
+                    items.size == 1 -> items.keys.single() != stack.active.key
+                    else -> items.keys.toList() != stackKeys
                 }
 
             if (updateItems) {


### PR DESCRIPTION
Fixes #772.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved handling of stack animations for scenarios with a single item, enhancing animation state accuracy.

- **Tests**
	- Added a new test case to verify that the previous child does not animate after a predictive back gesture is completed, increasing testing coverage for stack animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->