### PR TITLE
Disable input during predictive back animation

### DIFF
--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/AbstractStackAnimation.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/AbstractStackAnimation.kt
@@ -8,9 +8,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
 import com.arkivanov.decompose.Child
 import com.arkivanov.decompose.ExperimentalDecomposeApi
+import com.arkivanov.decompose.extensions.compose.utils.InputConsumingOverlay
 import com.arkivanov.decompose.router.stack.ChildStack
 
 @OptIn(ExperimentalDecomposeApi::class)
@@ -56,23 +56,9 @@ internal abstract class AbstractStackAnimation<C : Any, T : Any>(
             // A workaround until https://issuetracker.google.com/issues/214231672.
             // Normally only the exiting child should be disabled.
             if (disableInputDuringAnimation && (items.size > 1)) {
-                Overlay(modifier = Modifier.matchParentSize())
+                InputConsumingOverlay(modifier = Modifier.matchParentSize())
             }
         }
-    }
-
-    @Composable
-    private fun Overlay(modifier: Modifier) {
-        Box(
-            modifier = modifier.pointerInput(Unit) {
-                awaitPointerEventScope {
-                    while (true) {
-                        val event = awaitPointerEvent()
-                        event.changes.forEach { it.consume() }
-                    }
-                }
-            }
-        )
     }
 
     private fun getAnimationItems(newStack: ChildStack<C, T>, oldStack: ChildStack<C, T>?): Map<Any, AnimationItem<C, T>> =

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/PredictiveBackAnimation.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/PredictiveBackAnimation.kt
@@ -18,6 +18,7 @@ import com.arkivanov.decompose.Ref
 import com.arkivanov.decompose.extensions.compose.stack.animation.LocalStackAnimationProvider
 import com.arkivanov.decompose.extensions.compose.stack.animation.StackAnimation
 import com.arkivanov.decompose.extensions.compose.stack.animation.emptyStackAnimation
+import com.arkivanov.decompose.extensions.compose.utils.InputConsumingOverlay
 import com.arkivanov.decompose.router.stack.ChildStack
 import com.arkivanov.essenty.backhandler.BackCallback
 import com.arkivanov.essenty.backhandler.BackEvent
@@ -94,6 +95,10 @@ private class PredictiveBackAnimation<C : Any, T : Any>(
                         content = childContent,
                     )
                 }
+            }
+
+            if (handler.items.size > 1) {
+                InputConsumingOverlay(modifier = Modifier.matchParentSize())
             }
         }
 

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/utils/InputConsumingOverlay.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/utils/InputConsumingOverlay.kt
@@ -1,0 +1,20 @@
+package com.arkivanov.decompose.extensions.compose.utils
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+
+@Composable
+internal fun InputConsumingOverlay(modifier: Modifier) {
+    Box(
+        modifier = modifier.pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    val event = awaitPointerEvent()
+                    event.changes.forEach { it.consume() }
+                }
+            }
+        }
+    )
+}


### PR DESCRIPTION
Fixes #773.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `InputConsumingOverlay` to enhance input event handling during animations.
  - Added conditional rendering logic for `InputConsumingOverlay` in the predictive back animation to improve user interaction control.

- **Bug Fixes**
  - Simplified input handling by removing the custom `Overlay` function, maintaining functionality to prevent user interactions during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->