### PR TITLE
Don't seek stack animation transition on back start when predictive back animatable is specified

### DIFF
--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
@@ -264,7 +264,7 @@ internal class DefaultStackAnimation<C : Any, T : Any>(
             )
 
             scope.launch {
-                animationHandler.start(backEvent)
+                animationHandler.progress(backEvent)
             }
         }
 
@@ -300,14 +300,6 @@ internal class DefaultStackAnimation<C : Any, T : Any>(
     ) {
         val exitTransitionState: SeekableTransitionState<EnterExitState> = SeekableTransitionState(EnterExitState.Visible)
         val enterTransitionState: SeekableTransitionState<EnterExitState> = SeekableTransitionState(EnterExitState.PreEnter)
-
-        suspend fun start(backEvent: BackEvent) {
-            awaitAll(
-                { exitTransitionState.seekTo(fraction = backEvent.progress, targetState = EnterExitState.PostExit) },
-                { enterTransitionState.seekTo(fraction = backEvent.progress, targetState = EnterExitState.Visible) },
-                { animatable?.animate(backEvent) },
-            )
-        }
 
         suspend fun progress(backEvent: BackEvent) {
             animatable?.run {

--- a/extensions-compose-experimental/src/jvmTest/kotlin/com/arkivanov/decompose/extensions/compose/experimental/TestUtils.kt
+++ b/extensions-compose-experimental/src/jvmTest/kotlin/com/arkivanov/decompose/extensions/compose/experimental/TestUtils.kt
@@ -1,11 +1,28 @@
 package com.arkivanov.decompose.extensions.compose.experimental
 
+import androidx.compose.animation.EnterExitState
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import kotlin.test.fail
+
+@Composable
+internal fun Transition<EnterExitState>.animateFloat(): State<Float> =
+    animateFloat(transitionSpec = { tween(easing = LinearEasing) }) { state ->
+        when (state) {
+            EnterExitState.PreEnter -> 0F
+            EnterExitState.Visible -> 1F
+            EnterExitState.PostExit -> 0F
+        }
+    }
 
 internal fun SemanticsNodeInteraction.assertTestTagToRootExists(testTag: String) {
     val count = collectTestTagsToRoot().filter { it == testTag }.size


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved back navigation animations for smoother transitions.
	- Introduced a new composable function for float animations in transition states.
	- Enhanced testing for predictive back gestures with new scenarios.

- **Bug Fixes**
	- Resolved issues with animation behavior during stack transitions.

- **Documentation**
	- Updated method names and signatures for clarity in animation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->