### PR TITLE
Add an example of using window size classes with ChildPanelsMode

### DIFF
--- a/docs/extensions/compose.md
+++ b/docs/extensions/compose.md
@@ -294,12 +294,39 @@ The default `HorizontalChildPanelsLayout` layout places child components (panels
 - If the `mode` is `DUAL`, the Main panel is always displayed on the left side, and then the Details and the Extra panels are displayed in a stack on the right side (next to the Main panel).
 - If the `mode` is `TRIPLE`, all panels are displayed horizontally side by side.
 
+You can use window size classes from the `material3-window-size-class` package to determine which `ChildPanelsMode` should be used.
+
+```kotlin title="WindowSizeClass example"
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+
+@Composable
+fun MyApp() {
+    val windowSizeClass = calculateWindowSizeClass()
+    val mode = if (windowSizeClass.widthSizeClass < WindowWidthSizeClass.Expanded) {
+        ChildPanelsMode.SINGLE
+    } else {
+        ChildPanelsMode.DUAL
+    }
+    /* ... */
+}
+```
+
+!!!warning
+    Function calculateWindowSizeClass will cause recomposition on every window size change. Try to reduce the recomposition scope.
+
 ```kotlin title="Basic example"
 import androidx.compose.runtime.Composable
 import com.arkivanov.decompose.extensions.compose.experimental.panels.ChildPanels
+import com.arkivanov.decompose.router.panels.ChildPanelsMode
 
 @Composable
-fun PanelsContent(component: PanelsComponent) {
+fun PanelsContent(component: PanelsComponent, mode: ChildPanelsMode) {
+    DisposableEffect(mode) {
+        component.setMode(mode)
+        onDispose { }
+    }
+
     ChildPanels(
         panels = component.panels,
         mainChild = { MainContent(it.instance) },
@@ -327,9 +354,15 @@ import com.arkivanov.decompose.extensions.compose.experimental.stack.animation.f
 import com.arkivanov.decompose.extensions.compose.experimental.stack.animation.plus
 import com.arkivanov.decompose.extensions.compose.experimental.stack.animation.scale
 import com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback.materialPredictiveBackAnimatable
+import com.arkivanov.decompose.router.panels.ChildPanelsMode
 
 @Composable
-fun PanelsContent(component: PanelsComponent) {
+fun PanelsContent(component: PanelsComponent, mode: ChildPanelsMode) {
+    DisposableEffect(mode) {
+        component.setMode(mode)
+        onDispose { }
+    }
+
     ChildPanels(
         panels = component.panels,
         mainChild = { MainContent(it.instance) },

--- a/docs/extensions/compose.md
+++ b/docs/extensions/compose.md
@@ -298,21 +298,23 @@ You can use window size classes from the `material3-window-size-class` package t
 
 ```kotlin title="WindowSizeClass example"
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass.Companion.Expanded
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import com.arkivanov.decompose.router.panels.ChildPanelsMode
+import com.arkivanov.decompose.router.panels.ChildPanelsMode.SINGLE
+import com.arkivanov.decompose.router.panels.ChildPanelsMode.DUAL
 
 @Composable
-fun calculatePanelsMode(): ChildPanelsMode {
+fun ChildPanelsModeChangedEffect(onModeChanged: (ChildPanelsMode) -> Unit) {
     val windowSize = calculateWindowSizeClass()
-    return if (windowSize.widthSizeClass < WindowWidthSizeClass.Expanded) {
-        ChildPanelsMode.SINGLE
-    } else {
-        ChildPanelsMode.DUAL
+    val mode = if (windowSize.widthSizeClass < Expanded) SINGLE else DUAL
+
+    DisposableEffect(mode) {
+        onModeChanged(mode)
+        onDispose {}
     }
 }
 ```
-
-!!!warning
-    Function calculateWindowSizeClass will cause recomposition on every window size change. Try to reduce the recomposition scope.
 
 ```kotlin title="Basic example"
 import androidx.compose.runtime.Composable
@@ -321,11 +323,7 @@ import com.arkivanov.decompose.router.panels.ChildPanelsMode
 
 @Composable
 fun PanelsContent(component: PanelsComponent) {
-    val mode = calculatePanelsMode()
-    DisposableEffect(mode) {
-        component.setMode(mode)
-        onDispose { }
-    }
+    ChildPanelsModeChangedEffect(component::setMode)
 
     ChildPanels(
         panels = component.panels,
@@ -358,11 +356,7 @@ import com.arkivanov.decompose.router.panels.ChildPanelsMode
 
 @Composable
 fun PanelsContent(component: PanelsComponent) {
-    val mode = calculatePanelsMode()
-    DisposableEffect(mode) {
-        component.setMode(mode)
-        onDispose { }
-    }
+    ChildPanelsModeChangedEffect(component::setMode)
 
     ChildPanels(
         panels = component.panels,

--- a/docs/extensions/compose.md
+++ b/docs/extensions/compose.md
@@ -301,14 +301,13 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 
 @Composable
-fun MyApp() {
-    val windowSizeClass = calculateWindowSizeClass()
-    val mode = if (windowSizeClass.widthSizeClass < WindowWidthSizeClass.Expanded) {
+fun calculatePanelsMode(): ChildPanelsMode {
+    val windowSize = calculateWindowSizeClass()
+    return if (windowSize.widthSizeClass < WindowWidthSizeClass.Expanded) {
         ChildPanelsMode.SINGLE
     } else {
         ChildPanelsMode.DUAL
     }
-    /* ... */
 }
 ```
 
@@ -321,7 +320,8 @@ import com.arkivanov.decompose.extensions.compose.experimental.panels.ChildPanel
 import com.arkivanov.decompose.router.panels.ChildPanelsMode
 
 @Composable
-fun PanelsContent(component: PanelsComponent, mode: ChildPanelsMode) {
+fun PanelsContent(component: PanelsComponent) {
+    val mode = calculatePanelsMode()
     DisposableEffect(mode) {
         component.setMode(mode)
         onDispose { }
@@ -357,7 +357,8 @@ import com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback
 import com.arkivanov.decompose.router.panels.ChildPanelsMode
 
 @Composable
-fun PanelsContent(component: PanelsComponent, mode: ChildPanelsMode) {
+fun PanelsContent(component: PanelsComponent) {
+    val mode = calculatePanelsMode()
     DisposableEffect(mode) {
         component.setMode(mode)
         onDispose { }


### PR DESCRIPTION
The current documentation is not entirely clear on how to switch the mode in ChildPanels depending on the current size of the application window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced integration of Decompose with Jetpack Compose, focusing on lifecycle management, navigation, and animations.
	- Introduced a new `ChildPanelsModeChangedEffect` for responsive layout adjustments based on window size.
	- Improved `PanelsContent` to react to window size changes and support animations for child components.

- **Documentation**
	- Updated `compose.md` with comprehensive details on new features, usage instructions, and lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->