### PR TITLE
Cancel predictive back gesture when stack changed (experimental animation API)

### DIFF
--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
@@ -69,7 +69,7 @@ internal class DefaultStackAnimation<C : Any, T : Any>(
 
             if (updateItems) {
                 val newItems = getAnimationItems(newStack = currentStack, oldStack = oldStack)
-                if (items.size == 1) {
+                if ((items.size == 1) || items.values.last().transitionState.isSeekable()) {
                     items = newItems
                 } else {
                     nextItems = newItems
@@ -401,3 +401,6 @@ private fun TransitionState<*>.isIdle(): Boolean =
         is SeekableTransitionState -> false
         else -> false
     }
+
+private fun TransitionState<*>.isSeekable(): Boolean =
+    this is SeekableTransitionState


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced animation handling during stack transitions with new conditions for seekable transition states.
	- Added a new private function to check if a transition state is seekable.

- **Bug Fixes**
	- Introduced a test case for predictive back gesture behavior to ensure correct cancellation when the stack is popped.

- **Documentation**
	- Updated method signatures to improve clarity and functionality in animation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->