### PR TITLE
Fixed details panel placeholder showing in SINGLE mode

### DIFF
--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanels.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanels.kt
@@ -320,7 +320,12 @@ private fun <DC : Any, DT : Any> DetailsPanel(
     ) {
         when (val child = it.instance) {
             is PanelChild.Panel -> content(child.child)
-            is PanelChild.Empty -> placeholder()
+
+            is PanelChild.Empty -> {
+                if (it == EmptyChild3) {
+                    placeholder()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of empty child panels in the UI, improving the specificity of placeholder display.
	- Introduced overloaded versions of the `ChildPanels` function for more flexible usage.

- **Bug Fixes**
	- Refined logic in the `DetailsPanel` function to conditionally display placeholders based on the specific empty child instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->