### PR TITLE
samples.md typo fix

### DIFF
--- a/docs/samples.md
+++ b/docs/samples.md
@@ -67,7 +67,7 @@ Content:
 <img src="https://raw.githubusercontent.com/arkivanov/Decompose/master/docs/media/SampleCountersDesktop.png" width="294">
 <img src="https://raw.githubusercontent.com/arkivanov/Decompose/master/docs/media/SampleCountersWeb.png" width="294">
 
-### Swipeable Cards Screenhots
+### Swipeable Cards Screenshots
 
 <img src="https://raw.githubusercontent.com/arkivanov/Decompose/master/docs/media/SampleCardsAndroid.gif" width="196">
 


### PR DESCRIPTION
"Swipeable Cards Screenhots" replaced with "Swipeable Cards Screen**s**hots"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected heading from "Swipeable Cards Screenhots" to "Swipeable Cards Screenshots" in the Multi-Feature Sample App documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->