### PR TITLE
Check the Gradle distribution checksum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=89d4e70e4e84e2d2dfbb63e4daa53e21b25017cc70c37e4eea31ee51fb15098a
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
It is generally a good idea to ensure the integrity of the Gradle distribution to prevent MITM attacks when downloading. (See https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification)

Keep in mind that this has to be updated alongside the distribution link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build process security by adding a checksum verification step to ensure the authenticity of the build package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->