### PR TITLE
Don't restart Activity stack when there is no deep link

### DIFF
--- a/decompose/src/androidMain/kotlin/com/arkivanov/decompose/DeeplinkUtils.kt
+++ b/decompose/src/androidMain/kotlin/com/arkivanov/decompose/DeeplinkUtils.kt
@@ -48,13 +48,15 @@ import androidx.savedstate.SavedStateRegistryOwner
 fun <A, T : Any> A.handleDeepLink(
     block: (Uri?) -> T,
 ): T? where A : Activity, A : SavedStateRegistryOwner {
-    if (restartIfNeeded()) {
+    val intentData: Uri? = intent.data
+
+    if ((intentData != null) && restartIfNeeded()) {
         return null
     }
 
     val savedState: Bundle? = savedStateRegistry.consumeRestoredStateForKey(key = KEY_SAVED_DEEP_LINK_STATE)
     val isDeepLinkHandled = savedState?.getBoolean(KEY_DEEP_LINK_HANDLED) ?: false
-    val deepLink = intent.data.takeUnless { isDeepLinkHandled }
+    val deepLink = intentData?.takeUnless { isDeepLinkHandled }
 
     savedStateRegistry.registerSavedStateProvider(key = KEY_SAVED_DEEP_LINK_STATE) {
         bundleOf(KEY_DEEP_LINK_HANDLED to (isDeepLinkHandled || (deepLink != null)))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced deep link processing to ensure that the app triggers a restart only when valid deep link data is available, improving stability and preventing unintended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->