### PR TITLE
Deprecated Value#getValue operator overload

### DIFF
--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/value/ValueExt.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/value/ValueExt.kt
@@ -5,6 +5,13 @@ import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.lifecycle.subscribe
 import kotlin.reflect.KProperty
 
+@Deprecated(
+    "Using this operator overload is known to be error prone. " +
+        "In particular, it can be accidentally used in Compose to observe the value, which will not work as expected. " +
+        "Instead, you can write: `val stack by fooComponent::stack`. " +
+        "Alternatively, feel free to copy it into your project if you want to continue using it. " +
+        "See: https://github.com/arkivanov/Decompose/issues/871",
+)
 operator fun <T : Any> Value<T>.getValue(thisRef: Any?, property: KProperty<*>): T = value
 
 fun <T : Any> Value<T>.subscribe(

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/TestUtils.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/TestUtils.kt
@@ -1,9 +1,11 @@
 package com.arkivanov.decompose
 
+import com.arkivanov.decompose.value.Value
 import com.arkivanov.essenty.statekeeper.StateKeeper
 import com.arkivanov.essenty.statekeeper.StateKeeperDispatcher
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
+import kotlin.reflect.KProperty
 
 internal val json =
     Json {
@@ -27,3 +29,5 @@ fun StateKeeperDispatcher.recreate(isConfigurationChange: Boolean = false): Stat
     StateKeeperDispatcher(
         savedState = save().let { if (isConfigurationChange) it else it.serializeAndDeserialize() },
     )
+
+operator fun <T : Any> Value<T>.getValue(thisRef: Any?, property: KProperty<*>): T = value

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildControllerTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildControllerTest.kt
@@ -13,7 +13,6 @@ import com.arkivanov.decompose.router.TestInstance
 import com.arkivanov.decompose.serializeAndDeserialize
 import com.arkivanov.essenty.instancekeeper.getOrCreate
 import com.arkivanov.essenty.lifecycle.Lifecycle
-import kotlinx.serialization.builtins.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -22,6 +21,7 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlinx.serialization.builtins.serializer
 
 @Suppress("TestFunctionName")
 class ChildControllerTest {

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenBackPressedTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenBackPressedTest.kt
@@ -4,11 +4,11 @@ import com.arkivanov.decompose.TestBackCallback
 import com.arkivanov.decompose.TestBackCallback.Event.OnBack
 import com.arkivanov.decompose.assertEvents
 import com.arkivanov.decompose.assertNoEvents
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.router.children.ChildNavState.Status.CREATED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.DESTROYED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.RESUMED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.STARTED
-import com.arkivanov.decompose.value.getValue
 import com.arkivanov.essenty.backhandler.BackCallback
 import kotlin.test.Test
 import kotlin.test.assertContentEquals

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenBasicTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenBasicTest.kt
@@ -2,13 +2,13 @@ package com.arkivanov.decompose.router.children
 
 import com.arkivanov.decompose.DecomposeExperimentFlags
 import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.router.TestInstance
 import com.arkivanov.decompose.router.children.ChildNavState.Status.CREATED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.DESTROYED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.RESUMED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.STARTED
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
-import com.arkivanov.decompose.value.getValue
 import com.arkivanov.essenty.instancekeeper.getOrCreate
 import com.arkivanov.essenty.lifecycle.destroy
 import com.arkivanov.essenty.lifecycle.doOnDestroy
@@ -294,6 +294,7 @@ class ChildrenBasicTest : ChildrenTestBase() {
 
         children.assertChildren(3 to 3, 1 to 1, 2 to 2)
     }
+
     @Test
     fun GIVEN_duplicated_children_WHEN_remove_duplicated_children_from_start_THEN_duplicated_instances_removed_from_end() {
         DecomposeExperimentFlags.duplicateConfigurationsEnabled = true

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenLifecycleTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenLifecycleTest.kt
@@ -1,11 +1,11 @@
 package com.arkivanov.decompose.router.children
 
 import com.arkivanov.decompose.DecomposeExperimentFlags
-import com.arkivanov.decompose.router.children.ChildNavState.Status.RESUMED
-import com.arkivanov.decompose.router.children.ChildNavState.Status.DESTROYED
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.router.children.ChildNavState.Status.CREATED
+import com.arkivanov.decompose.router.children.ChildNavState.Status.DESTROYED
+import com.arkivanov.decompose.router.children.ChildNavState.Status.RESUMED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.STARTED
-import com.arkivanov.decompose.value.getValue
 import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.lifecycle.destroy
 import com.arkivanov.essenty.lifecycle.stop

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenRetainedInstanceTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenRetainedInstanceTest.kt
@@ -2,13 +2,13 @@ package com.arkivanov.decompose.router.children
 
 import com.arkivanov.decompose.DecomposeExperimentFlags
 import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.router.TestInstance
 import com.arkivanov.decompose.router.children.ChildNavState.Status.CREATED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.DESTROYED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.RESUMED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.STARTED
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
-import com.arkivanov.decompose.value.getValue
 import com.arkivanov.essenty.instancekeeper.InstanceKeeperDispatcher
 import com.arkivanov.essenty.instancekeeper.getOrCreate
 import kotlin.test.Test

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenSavedStateTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenSavedStateTest.kt
@@ -3,13 +3,13 @@ package com.arkivanov.decompose.router.children
 import com.arkivanov.decompose.DecomposeExperimentFlags
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.consume
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.register
-import com.arkivanov.decompose.router.children.ChildNavState.Status.RESUMED
-import com.arkivanov.decompose.router.children.ChildNavState.Status.DESTROYED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.CREATED
+import com.arkivanov.decompose.router.children.ChildNavState.Status.DESTROYED
+import com.arkivanov.decompose.router.children.ChildNavState.Status.RESUMED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.STARTED
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
-import com.arkivanov.decompose.value.getValue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -336,7 +336,10 @@ class ChildrenSavedStateTest : ChildrenTestBase() {
     fun GIVEN_not_saving_state_WHEN_recreated_THEN_child_states_not_restored() {
         val oldStateKeeper = TestStateKeeperDispatcher()
         val oldContext = DefaultComponentContext(lifecycle = lifecycle, stateKeeper = oldStateKeeper)
-        val oldChildren by oldContext.children(initialState = stateOf(1 by DESTROYED, 2 by CREATED, 3 by STARTED, 4 by RESUMED), saveState = { null })
+        val oldChildren by oldContext.children(
+            initialState = stateOf(1 by DESTROYED, 2 by CREATED, 3 by STARTED, 4 by RESUMED),
+            saveState = { null },
+        )
         oldChildren.getByConfig(config = 2).requireInstance().stateKeeper.register(key = "key") { 20 }
         oldChildren.getByConfig(config = 3).requireInstance().stateKeeper.register(key = "key") { 30 }
         oldChildren.getByConfig(config = 4).requireInstance().stateKeeper.register(key = "key") { 40 }
@@ -366,7 +369,10 @@ class ChildrenSavedStateTest : ChildrenTestBase() {
         val savedState = oldStateKeeper.save()
         val newStateKeeper = TestStateKeeperDispatcher(savedState)
         val newContext = DefaultComponentContext(lifecycle = lifecycle, stateKeeper = newStateKeeper)
-        val newChildren by newContext.children(initialState = stateOf(1 by DESTROYED, 2 by CREATED, 3 by STARTED, 4 by RESUMED), restoreState = { null })
+        val newChildren by newContext.children(
+            initialState = stateOf(1 by DESTROYED, 2 by CREATED, 3 by STARTED, 4 by RESUMED),
+            restoreState = { null },
+        )
         val restoredState2 = newChildren.getByConfig(config = 2).requireInstance().stateKeeper.consume<Int>(key = "key")
         val restoredState3 = newChildren.getByConfig(config = 3).requireInstance().stateKeeper.consume<Int>(key = "key")
         val restoredState4 = newChildren.getByConfig(config = 4).requireInstance().stateKeeper.consume<Int>(key = "key")

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/items/LazyItemsNavigationTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/items/LazyItemsNavigationTest.kt
@@ -1,8 +1,13 @@
 package com.arkivanov.decompose.router.items
 
 import com.arkivanov.decompose.TestComponentContext
-import com.arkivanov.decompose.router.items.LazyComponentState.*
 import com.arkivanov.decompose.router.items.Items.ActiveLifecycleState
+import com.arkivanov.decompose.router.items.LazyComponentState.CREATED
+import com.arkivanov.decompose.router.items.LazyComponentState.DESTROYED
+import com.arkivanov.decompose.router.items.LazyComponentState.PENDING
+import com.arkivanov.decompose.router.items.LazyComponentState.REMOVED
+import com.arkivanov.decompose.router.items.LazyComponentState.RESUMED
+import com.arkivanov.decompose.router.items.LazyComponentState.STARTED
 import kotlin.test.Test
 
 @Suppress("TestFunctionName")

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/items/LazyItemsRetainedInstanceTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/items/LazyItemsRetainedInstanceTest.kt
@@ -5,7 +5,11 @@ import com.arkivanov.decompose.recreate
 import com.arkivanov.decompose.router.TestInstance
 import com.arkivanov.decompose.router.items.Items.ActiveLifecycleState
 import com.arkivanov.essenty.instancekeeper.getOrCreate
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 @Suppress("TestFunctionName")
 class LazyItemsRetainedInstanceTest {

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesBackButtonTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesBackButtonTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.DefaultComponentContext
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.getValue
 import com.arkivanov.essenty.backhandler.BackDispatcher
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesClearTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesClearTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.DefaultComponentContext
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.getValue
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import kotlin.test.BeforeTest

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesIntegrationTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesIntegrationTest.kt
@@ -2,9 +2,9 @@ package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
 import com.arkivanov.decompose.value.Value
-import com.arkivanov.decompose.value.getValue
 import com.arkivanov.essenty.backhandler.BackDispatcher
 import com.arkivanov.essenty.instancekeeper.InstanceKeeperDispatcher
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSavedStateTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSavedStateTest.kt
@@ -1,11 +1,10 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
-import com.arkivanov.decompose.value.getValue
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
-import com.arkivanov.essenty.statekeeper.StateKeeperDispatcher
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectFirstTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectFirstTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.DefaultComponentContext
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.getValue
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import kotlin.test.BeforeTest

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectLastTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectLastTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.DefaultComponentContext
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.getValue
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import kotlin.test.BeforeTest

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectNextTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectNextTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.DefaultComponentContext
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.getValue
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import kotlin.test.BeforeTest

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectPrevTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectPrevTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.DefaultComponentContext
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.getValue
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import kotlin.test.BeforeTest

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSelectTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.DefaultComponentContext
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.getValue
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import kotlin.test.BeforeTest

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSetItemsTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSetItemsTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.TestComponentContext
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.getValue
 import kotlin.test.Test
 
 @Suppress("TestFunctionName")

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/panels/ChildPanelsBackButtonTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/panels/ChildPanelsBackButtonTest.kt
@@ -1,10 +1,10 @@
 package com.arkivanov.decompose.router.panels
 
 import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.router.panels.ChildPanelsMode.DUAL
 import com.arkivanov.decompose.router.panels.ChildPanelsMode.SINGLE
 import com.arkivanov.decompose.router.panels.ChildPanelsMode.TRIPLE
-import com.arkivanov.decompose.value.getValue
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/panels/ChildPanelsNavigationTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/panels/ChildPanelsNavigationTest.kt
@@ -1,10 +1,10 @@
 package com.arkivanov.decompose.router.panels
 
 import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.router.panels.ChildPanelsMode.DUAL
 import com.arkivanov.decompose.router.panels.ChildPanelsMode.SINGLE
 import com.arkivanov.decompose.router.panels.ChildPanelsMode.TRIPLE
-import com.arkivanov.decompose.value.getValue
 import com.arkivanov.essenty.lifecycle.Lifecycle.State.DESTROYED
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/panels/ChildPanelsSavedStateTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/panels/ChildPanelsSavedStateTest.kt
@@ -1,10 +1,10 @@
 package com.arkivanov.decompose.router.panels
 
 import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.router.panels.ChildPanelsMode.DUAL
 import com.arkivanov.decompose.router.panels.ChildPanelsMode.SINGLE
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
-import com.arkivanov.decompose.value.getValue
 import kotlin.test.Test
 
 @Suppress("TestFunctionName")

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/slot/ChildSlotIntegrationTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/slot/ChildSlotIntegrationTest.kt
@@ -4,11 +4,11 @@ import com.arkivanov.decompose.Child
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.consume
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.register
 import com.arkivanov.decompose.router.TestInstance
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
 import com.arkivanov.decompose.value.Value
-import com.arkivanov.decompose.value.getValue
 import com.arkivanov.essenty.backhandler.BackDispatcher
 import com.arkivanov.essenty.instancekeeper.InstanceKeeperDispatcher
 import com.arkivanov.essenty.instancekeeper.getOrCreate

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/stack/ChildStackIntegrationTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/stack/ChildStackIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.arkivanov.decompose.DecomposeExperimentFlags
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.DelicateDecomposeApi
 import com.arkivanov.decompose.consume
+import com.arkivanov.decompose.getValue
 import com.arkivanov.decompose.lifecycle.TestLifecycleCallbacks
 import com.arkivanov.decompose.lifecycle.TestLifecycleCallbacks.Event.ON_CREATE
 import com.arkivanov.decompose.lifecycle.TestLifecycleCallbacks.Event.ON_DESTROY
@@ -16,7 +17,6 @@ import com.arkivanov.decompose.register
 import com.arkivanov.decompose.router.TestInstance
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
 import com.arkivanov.decompose.value.Value
-import com.arkivanov.decompose.value.getValue
 import com.arkivanov.essenty.backhandler.BackCallback
 import com.arkivanov.essenty.backhandler.BackDispatcher
 import com.arkivanov.essenty.instancekeeper.InstanceKeeperDispatcher

--- a/sample/shared/dynamic-features/feature1Impl/build.gradle.kts
+++ b/sample/shared/dynamic-features/feature1Impl/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
 
         common.main.dependencies {
             implementation(project(":decompose"))
+            implementation(project(":extensions-compose"))
             implementation(project(":sample:shared:dynamic-features:api"))
             implementation(deps.reaktive.reaktive)
         }

--- a/sample/shared/dynamic-features/feature1Impl/src/androidMain/kotlin/com/arkivanov/sample/shared/dynamicfeatures/feature1/Feature1Content.kt
+++ b/sample/shared/dynamic-features/feature1Impl/src/androidMain/kotlin/com/arkivanov/sample/shared/dynamicfeatures/feature1/Feature1Content.kt
@@ -7,18 +7,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.sample.shared.dynamicfeatures.DynamicFeatureContent
 
+@Suppress("unused") // Used via reflection
 class Feature1Content : DynamicFeatureContent<Feature1> {
 
     @Suppress("ComposableNaming")
     @Composable
     override fun invoke(component: Feature1, modifier: Modifier) {
-        val model by component.models
+        val model by component.models.subscribeAsState()
 
         Column(
             modifier = modifier,

--- a/sample/shared/dynamic-features/feature1Impl/src/jvmMain/kotlin/com/arkivanov/sample/shared/dynamicfeatures/feature1/Feature1Content.kt
+++ b/sample/shared/dynamic-features/feature1Impl/src/jvmMain/kotlin/com/arkivanov/sample/shared/dynamicfeatures/feature1/Feature1Content.kt
@@ -7,10 +7,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.sample.shared.dynamicfeatures.DynamicFeatureContent
 
 class Feature1Content : DynamicFeatureContent<Feature1> {
@@ -18,7 +19,7 @@ class Feature1Content : DynamicFeatureContent<Feature1> {
     @Suppress("ComposableNaming")
     @Composable
     override fun invoke(component: Feature1, modifier: Modifier) {
-        val model by component.models
+        val model by component.models.subscribeAsState()
 
         Column(
             modifier = modifier,

--- a/sample/shared/dynamic-features/feature2Impl/build.gradle.kts
+++ b/sample/shared/dynamic-features/feature2Impl/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
 
         common.main.dependencies {
             implementation(project(":decompose"))
+            implementation(project(":extensions-compose"))
             implementation(project(":sample:shared:dynamic-features:api"))
             implementation(deps.reaktive.reaktive)
         }

--- a/sample/shared/dynamic-features/feature2Impl/src/androidMain/kotlin/com/arkivanov/sample/shared/dynamicfeatures/feature2/Feature2Content.kt
+++ b/sample/shared/dynamic-features/feature2Impl/src/androidMain/kotlin/com/arkivanov/sample/shared/dynamicfeatures/feature2/Feature2Content.kt
@@ -7,18 +7,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.sample.shared.dynamicfeatures.DynamicFeatureContent
 
+@Suppress("unused") // Used via reflection
 class Feature2Content : DynamicFeatureContent<Feature2> {
 
     @Suppress("ComposableNaming")
     @Composable
     override fun invoke(component: Feature2, modifier: Modifier) {
-        val model by component.models
+        val model by component.models.subscribeAsState()
 
         Column(
             modifier = modifier,

--- a/sample/shared/dynamic-features/feature2Impl/src/jvmMain/kotlin/com/arkivanov/sample/shared/dynamicfeatures/feature2/Feature2Content.kt
+++ b/sample/shared/dynamic-features/feature2Impl/src/jvmMain/kotlin/com/arkivanov/sample/shared/dynamicfeatures/feature2/Feature2Content.kt
@@ -7,10 +7,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.arkivanov.decompose.value.getValue
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.sample.shared.dynamicfeatures.DynamicFeatureContent
 
 class Feature2Content : DynamicFeatureContent<Feature2> {
@@ -18,7 +19,7 @@ class Feature2Content : DynamicFeatureContent<Feature2> {
     @Suppress("ComposableNaming")
     @Composable
     override fun invoke(component: Feature2, modifier: Modifier) {
-        val model by component.models
+        val model by component.models.subscribeAsState()
 
         Column(
             modifier = modifier,


### PR DESCRIPTION
Closes #871.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new test to verify correct handling of duplicated children in navigation state.

- **Bug Fixes**
	- Improved Compose UI reactivity by updating state observation in dynamic feature samples to use subscription-based state access.

- **Chores**
	- Added new dependencies to dynamic feature modules for enhanced Compose integration.
	- Updated import statements and deprecated a potentially error-prone operator to improve code clarity and future-proofing.
	- Added unused code suppression annotation for clarity in sample code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->