### PR TITLE
Removed kotlin-parcelize plugin from samples and docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -130,9 +130,6 @@ kotlin {
     
                 // Optional, only if you need state preservation on Darwin (Apple) targets
                 export("com.arkivanov.essenty:state-keeper:<essenty_version>")
-    
-                // Optional, only if you need state preservation on Darwin (Apple) targets
-                export("com.arkivanov.parcelize.darwin:runtime:<parcelize_darwin_version>")
             }
         }
     ...
@@ -156,9 +153,6 @@ kotlin {
 
             // Optional, only if you need state preservation on Darwin (Apple) targets
             export("com.arkivanov.essenty:state-keeper:<essenty_version>")
-
-            // Optional, only if you need state preservation on Darwin (Apple) targets
-            export("com.arkivanov.parcelize.darwin:runtime:<parcelize_darwin_version>")
         }
     }
     ...

--- a/sample/app-android/build.gradle.kts
+++ b/sample/app-android/build.gradle.kts
@@ -3,7 +3,6 @@ import com.arkivanov.gradle.setupAndroidApp
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    id("kotlin-parcelize")
     id("org.jetbrains.compose")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.arkivanov.gradle.setup")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed duplicate and unnecessary export statements for the Parcelize Darwin runtime from the installation guide for Kotlin Multiplatform iOS frameworks.

* **Chores**
  * Removed the kotlin-parcelize plugin from the Android app module's build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->