### PR TITLE
docs: Update package path for proguard rule

### DIFF
--- a/docs/extensions/compose.md
+++ b/docs/extensions/compose.md
@@ -11,7 +11,7 @@ Please see the corresponding [Installation docs section](../getting-started/inst
 If you support Compose for Desktop, you will need to add the following rule for ProGuard, so that the app works correctly in release mode. See [Minification & obfuscation](https://github.com/JetBrains/compose-multiplatform/tree/master/tutorials/Native_distributions_and_local_execution#minification--obfuscation) section in Compose docs for more information.
 
 ```
--keep class com.arkivanov.decompose.extensions.compose.jetbrains.mainthread.SwingMainThreadChecker
+-keep class com.arkivanov.decompose.extensions.compose.mainthread.SwingMainThreadChecker
 ```
 
 ## Converting Value to State


### PR DESCRIPTION
Small leftover from when there was a `compose.jetbrains` package.

Verified locally that this is the correct path and still works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ProGuard rule in the Compose for Desktop documentation to reflect the new class package path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->