### PR TITLE
Fixed incorrect enter shape in androidPredictiveBackAnimatable when not fullscreen

### DIFF
--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/AndroidPredictiveBackAnimatable.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/AndroidPredictiveBackAnimatable.kt
@@ -78,7 +78,7 @@ private class AndroidPredictiveBackAnimatable(
             Modifier.composed {
                 if (enterShape == null) {
                     withLayoutCorners { corners ->
-                        enterModifier { progress, _ -> corners.toShape(1F - progress) }
+                        enterModifier { progress, _ -> corners.toShape(progress) }
                     }
                 } else {
                     enterModifier(enterShape)
@@ -116,7 +116,7 @@ private class AndroidPredictiveBackAnimatable(
                 scaleY = scaleFactor,
                 alpha = totalProgress,
                 translationX = lerp(start = -size.width * 0.15F, stop = 0F, fraction = totalProgress),
-                shape = layoutShape(finishProgress, edge),
+                shape = layoutShape(lerp(start = enterProgress, stop = 0F, fraction = finishProgress), edge),
                 clip = true,
                 compositingStrategy = CompositingStrategy.Offscreen,
             ) // Not using `graphicsLayer {}` with lambda due to https://github.com/arkivanov/Decompose/issues/877


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed the Android predictive back enter animation so the entering surface’s shape now follows the live gesture progress for smoother, more natural morphing.
  - Eliminated a subtle visual jump at completion by basing the enter path on current progress rather than a finishing state; scale, alpha, and translation behavior unchanged.
  - No API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->