### PR TITLE
Fixed ChildPages animation sometimes stuck when interrupted

### DIFF
--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/pages/ChildPages.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/pages/ChildPages.kt
@@ -64,7 +64,7 @@ fun <C : Any, T : Any> ChildPages(
     )
 
     LaunchedEffect(selectedIndex) {
-        if (state.currentPage != selectedIndex) {
+        if (!state.isScrollInProgress) {
             when (scrollAnimation) {
                 is PagesScrollAnimation.Disabled -> state.scrollToPage(selectedIndex)
                 is PagesScrollAnimation.Default -> state.animateScrollToPage(page = selectedIndex)


### PR DESCRIPTION
Fixes #868.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents programmatic page scrolls from triggering while the user is actively swiping, reducing jitter and accidental jumps.
  * Ensures smoother, consistent animations for page transitions when idle.
  * Reduces chances of redundant scroll actions, improving overall paging stability.

* **Chores**
  * No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->