### PR TITLE
Set stackAnimationDirection to null when the animation is idle

### DIFF
--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
@@ -135,14 +135,15 @@ internal class DefaultStackAnimation<C : Any, T : Any>(
         content: @Composable StackAnimationScope.(child: Child.Created<C, T>) -> Unit
     ) {
         val transition = rememberTransition(item.transitionState)
+        val isTransitionIdle = item.transitionState.isIdle()
 
-        if (item.transitionState.isIdle()) {
+        if (isTransitionIdle) {
             LaunchedEffect(Unit) {
                 onFinished()
             }
         }
 
-        WithStackAnimationScope(item.direction, transition) {
+        WithStackAnimationScope(item.direction.takeUnless { isTransitionIdle }, transition) {
             Box(modifier = item.animator?.run { animate(item.direction) } ?: Modifier) {
                 content(item.child)
             }


### PR DESCRIPTION
Follow-up to #901.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured stack animation direction is null when idle and accurately reflects ENTER/EXIT states during push/pop, improving correctness across lifecycle transitions.

* **Performance**
  * Reduced redundant checks by caching the animation idle state for smoother behavior.

* **Tests**
  * Added comprehensive tests validating direction values during create, push, pop, and idle phases.
  * Refactored test setup with a helper to centralize common configuration and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->