### PR TITLE
Use remember with PagerState instead of rememberPagerState in ChildPages

### DIFF
--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/pages/ChildPages.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/pages/ChildPages.kt
@@ -4,12 +4,12 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerScope
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.VerticalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.Child
 import com.arkivanov.decompose.Ref
@@ -58,10 +58,15 @@ fun <C : Any, T : Any> ChildPages(
     pageContent: @Composable PagerScope.(index: Int, page: T) -> Unit,
 ) {
     val selectedIndex = pages.selectedIndex.coerceAtLeast(0)
-    val state = rememberPagerState(
-        initialPage = selectedIndex,
-        pageCount = { pages.items.size },
-    )
+    val pageCountState = rememberUpdatedState(pages.items.size)
+
+    val state =
+        remember {
+            PagerState(
+                currentPage = selectedIndex,
+                pageCount = { pageCountState.value },
+            )
+        }
 
     LaunchedEffect(selectedIndex) {
         if (!state.isScrollInProgress) {


### PR DESCRIPTION
Fixes #929 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Pager state handling updated to persist across UI recompositions and correctly track changing page counts, preserving scrolling behavior and animations.
  - No public API changes; integrations remain compatible and no user action is required.

- **Tests**
  - Added a test validating nested page selection and restoration when switching and reactivating pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->