### PR TITLE
Fixed Web History Navigation duplicates history items when nested

### DIFF
--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/Cancellation.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/Cancellation.kt
@@ -5,3 +5,9 @@ fun interface Cancellation {
 
     fun cancel()
 }
+
+internal fun Cancellation.doOnCancel(block: () -> Unit): Cancellation =
+    Cancellation {
+        cancel()
+        block()
+    }

--- a/decompose/src/webMain/kotlin/com/arkivanov/decompose/router/webhistory/WebHistoryNavigation.kt
+++ b/decompose/src/webMain/kotlin/com/arkivanov/decompose/router/webhistory/WebHistoryNavigation.kt
@@ -2,6 +2,7 @@ package com.arkivanov.decompose.router.webhistory
 
 import com.arkivanov.decompose.Cancellation
 import com.arkivanov.decompose.Json
+import com.arkivanov.decompose.doOnCancel
 import com.arkivanov.decompose.encodeURIComponent
 import com.arkivanov.decompose.router.stack.startsWith
 import com.arkivanov.decompose.router.stack.subscribe
@@ -173,7 +174,7 @@ private fun <T : Any> WebNavigation<T>.subscribe(
                     onUpdateUrl(inactiveNodes + nodeOf(item = activeItem, children = childNodes))
                 },
             )
-    }
+    }.doOnCancel { activeChildCancellation?.cancel() }
 }
 
 private fun <T : Any> WebNavigation<T>.onHistoryChanged(

--- a/decompose/src/webTest/kotlin/com/arkivanov/decompose/router/webhistory/WebHistoryNavigationTest.kt
+++ b/decompose/src/webTest/kotlin/com/arkivanov/decompose/router/webhistory/WebHistoryNavigationTest.kt
@@ -761,6 +761,24 @@ class WebHistoryNavigationTest {
         assertHistory(nav = nav, urls = listOf("/1/11", "/1/22", "/1/33"), index = 0)
     }
 
+    @Test
+    fun GIVEN_three_levels_nested_with_one_child_each_WHEN_inner_pushed_and_go_back_and_inner_pushed_THEN_two_items_in_history() {
+        val nav =
+            TestWebNavigation(initialHistory = listOf(1)) {
+                TestWebNavigation(initialHistory = listOf(1)) {
+                    TestWebNavigation(initialHistory = listOf(1))
+                }
+            }
+
+        enableWebHistory(nav, history)
+
+        nav.requireChild(1).requireChild(1).navigate(listOf(1, 2))
+        history.navigate(delta = -1)
+        nav.requireChild(1).requireChild(1).navigate(listOf(1, 2))
+
+        assertHistory(nav = nav, urls = listOf("/1/1/1", "/1/1/2"))
+    }
+
     private fun assertHistory(nav: TestWebNavigation, urls: List<String>, index: Int = urls.lastIndex) {
         history.assertStack(urls = urls, index = index)
         nav.assertHistory(urls = urls.slice(0..index))


### PR DESCRIPTION
Fixes #907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved nested web history handling to correctly cancel child subscriptions when a parent is canceled.
  * Ensures browser history remains accurate after navigating back and then pushing again in deeply nested navigation.
  * Enhances stability for multi-level navigation scenarios without changing public APIs.

* Tests
  * Added test coverage for three-level nested navigation, verifying correct history after back-and-push flows.
  * Expanded scenarios to validate consistent behavior across nested routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->