### PR TITLE
Fixed Child Stack and Child Pages incorrectly initialized when state not restored

### DIFF
--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/pages/ChildPagesFactory.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/pages/ChildPagesFactory.kt
@@ -126,10 +126,12 @@ fun <Ctx : GenericComponentContext<Ctx>, C : Any, T : Any> Ctx.childPages(
         },
         saveState = { savePages(it.pages) },
         restoreState = { container ->
-            PagesNavState(
-                pages = restorePages(container) ?: initialPages(),
-                pageStatus = pageStatus,
-            )
+            restorePages(container)?.let { restoredPages ->
+                PagesNavState(
+                    pages = restoredPages,
+                    pageStatus = pageStatus,
+                )
+            }
         },
         navTransformer = { state, event ->
             PagesNavState(

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/ChildStackFactory.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/ChildStackFactory.kt
@@ -115,7 +115,7 @@ fun <Ctx : GenericComponentContext<Ctx>, C : Any, T : Any> Ctx.childStack(
         key = key,
         initialState = { StackNavState(configurations = initialStack()) },
         saveState = { saveStack(it.configurations) },
-        restoreState = { container -> StackNavState(configurations = restoreStack(container) ?: initialStack()) },
+        restoreState = { container -> restoreStack(container)?.let(::StackNavState) },
         navTransformer = { state, event -> StackNavState(configurations = event.transformer(state.configurations)) },
         stateMapper = { _, children ->
             @Suppress("UNCHECKED_CAST")

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSavedStateTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/pages/ChildPagesSavedStateTest.kt
@@ -1,12 +1,24 @@
 package com.arkivanov.decompose.router.pages
 
 import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.decompose.router.TestInstance
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
+import com.arkivanov.decompose.testutils.TestComponentContext
+import com.arkivanov.decompose.testutils.consume
 import com.arkivanov.decompose.testutils.getValue
+import com.arkivanov.decompose.testutils.recreate
+import com.arkivanov.decompose.testutils.register
+import com.arkivanov.essenty.instancekeeper.getOrCreate
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
+import com.arkivanov.essenty.statekeeper.SerializableContainer
+import kotlinx.serialization.builtins.serializer
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @Suppress("TestFunctionName")
 class ChildPagesSavedStateTest : BaseChildPagesTest() {
@@ -36,6 +48,81 @@ class ChildPagesSavedStateTest : BaseChildPagesTest() {
     }
 
     @Test
+    fun GIVEN_persistent_WHEN_recreated_with_new_initial_pages_and_state_not_restored_THEN_new_initial_pages_set() {
+        var ctx = TestComponentContext()
+        ctx.childPages(initialPages = Pages(items = listOf(1), selectedIndex = 0), persistent = true)
+
+        ctx = ctx.recreate()
+        val newPages by ctx.childPages(
+            source = navigation,
+            initialPages = { Pages(items = listOf(2, 3), selectedIndex = 1) },
+            savePages = { SerializableContainer(it, Pages.serializer(Int.serializer())) },
+            restorePages = { null },
+            childFactory = ::Component,
+        )
+
+        newPages.assertPages(ids = listOf(2, 3), selectedIndex = 1)
+    }
+
+    @Test
+    fun GIVEN_persistent_WHEN_recreated_with_same_initial_pages_and_state_not_restored_THEN_child_state_not_restored() {
+        var ctx = TestComponentContext()
+        val oldPages by ctx.childPages(initialPages = Pages(items = listOf(1), selectedIndex = 0), persistent = true)
+        oldPages.requireInstance(0).stateKeeper.register("key") { 1 }
+
+        ctx = ctx.recreate()
+        val newPages by ctx.childPages(
+            source = navigation,
+            initialPages = { Pages(items = listOf(1), selectedIndex = 0) },
+            savePages = { SerializableContainer(it, Pages.serializer(Int.serializer())) },
+            restorePages = { null },
+            childFactory = ::Component,
+        )
+
+        val restoredState = newPages.requireInstance(0).stateKeeper.consume<Int>("key")
+
+        assertNull(restoredState)
+    }
+
+    @Test
+    fun GIVEN_persistent_WHEN_config_changed_with_same_initial_pages_and_state_not_restored_THEN_child_retained_instances_destroyed() {
+        var ctx = TestComponentContext()
+        val oldPages by ctx.childPages(initialPages = Pages(items = listOf(1), selectedIndex = 0), persistent = true)
+        val oldInstance = oldPages.requireInstance(0).instanceKeeper.getOrCreate { TestInstance() }
+
+        ctx = ctx.recreate(isConfigurationChange = true)
+        ctx.childPages(
+            source = navigation,
+            initialPages = { Pages(items = listOf(1), selectedIndex = 0) },
+            savePages = { SerializableContainer(it, Pages.serializer(Int.serializer())) },
+            restorePages = { null },
+            childFactory = ::Component,
+        )
+
+        assertTrue(oldInstance.isDestroyed)
+    }
+
+    @Test
+    fun GIVEN_persistent_WHEN_config_changed_with_same_initial_pages_and_state_not_restored_THEN_retained_instances_are_not_same() {
+        var ctx = TestComponentContext()
+        val oldPages by ctx.childPages(initialPages = Pages(items = listOf(1), selectedIndex = 0), persistent = true)
+        val oldInstance = oldPages.requireInstance(0).instanceKeeper.getOrCreate { TestInstance() }
+
+        ctx = ctx.recreate(isConfigurationChange = true)
+        val newPages by ctx.childPages(
+            source = navigation,
+            initialPages = { Pages(items = listOf(1), selectedIndex = 0) },
+            savePages = { SerializableContainer(it, Pages.serializer(Int.serializer())) },
+            restorePages = { null },
+            childFactory = ::Component,
+        )
+        val newInstance = newPages.requireInstance(0).instanceKeeper.getOrCreate { TestInstance() }
+
+        assertNotSame(newInstance, oldInstance)
+    }
+
+
+    @Test
     fun GIVEN_not_persistent_WHEN_recreated_THEN_initial_state_applied() {
         var stateKeeper = TestStateKeeperDispatcher()
         var context = DefaultComponentContext(lifecycle = lifecycle, stateKeeper = stateKeeper)
@@ -51,4 +138,7 @@ class ChildPagesSavedStateTest : BaseChildPagesTest() {
 
         pages2.assertPages(ids = listOf(5, 6, 7), selectedIndex = 0)
     }
+
+    private fun ChildPages<Int, Component>.requireInstance(index: Int): Component =
+        assertNotNull(items[index].instance)
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - State restoration now returns null when no saved pages/stacks exist instead of falling back to initial state, preventing unintended reinitialization.
  - Ensures new initial pages/stacks are used on recreation when restoration isn’t applied.
  - Ensures retained child instances are destroyed and recreated correctly on configuration changes.

- Tests
  - Added comprehensive tests for persistent recreation, non-restoration scenarios, configuration changes, and instance lifecycle verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->