### PR TITLE
Added --no-parallel to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,15 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
+      - name: Build
+        run: ./gradlew publishToMavenLocal
       - name: Publish
         env:
           SONATYPE_USER_NAME: ${{ secrets.SONATYPE_USER_NAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew publish
+        run: ./gradlew publish --no-parallel
       - name: Close staging repository
         run: 'curl -H "Authorization: Bearer ${{ secrets.SONATYPE_AUTH_BASE64 }}" -X POST https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/com.arkivanov.decompose'
       - name: Check publication


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release pipeline to include a pre-publish local build step to validate artifacts before publishing.
  * Modified the publish step to run without parallelization for improved stability and fewer race conditions.
  * Provides clearer separation between build and publish stages, aiding troubleshooting.
  * Improves reliability of releases; no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->