### PR TITLE
Only show Extra panel placeholder in TRIPLE mode

### DIFF
--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanels.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanels.kt
@@ -342,7 +342,14 @@ private fun <EC : Any, ET : Any> ExtraPanel(
     placeholder: @Composable StackAnimationScope.() -> Unit,
 ) {
     ChildStack(
-        stack = stackOfNotNull(if (mode == SINGLE) EmptyChild1 else EmptyChild2, extra),
+        stack = stackOfNotNull(
+            when (mode) {
+                SINGLE -> EmptyChild1
+                DUAL -> EmptyChild2
+                TRIPLE -> EmptyChild3
+            },
+            extra,
+        ),
         modifier = Modifier.fillMaxSize(),
         animation = stackAnimation(
             animator = when (mode) {
@@ -355,7 +362,12 @@ private fun <EC : Any, ET : Any> ExtraPanel(
     ) {
         when (val child = it.instance) {
             is PanelChild.Panel -> content(child.child)
-            is PanelChild.Empty -> placeholder()
+
+            is PanelChild.Empty -> {
+                if (it == EmptyChild3) {
+                    placeholder()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed panel initialization logic to correctly respond to different layout modes.
  * Refined placeholder display behavior to appear only in appropriate panel states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->