### PR TITLE
Promoted the Duplicate Configurations feature to stable

### DIFF
--- a/decompose/api/android/decompose.api
+++ b/decompose/api/android/decompose.api
@@ -66,6 +66,25 @@ public final class com/arkivanov/decompose/DecomposeExperimentFlags {
 	public final fun setDuplicateConfigurationsEnabled (Z)V
 }
 
+public final class com/arkivanov/decompose/DecomposeSettings {
+	public static final field Companion Lcom/arkivanov/decompose/DecomposeSettings$Companion;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/arkivanov/decompose/DecomposeSettings;
+	public static synthetic fun copy$default (Lcom/arkivanov/decompose/DecomposeSettings;ZILjava/lang/Object;)Lcom/arkivanov/decompose/DecomposeSettings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuplicateConfigurationsEnabled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arkivanov/decompose/DecomposeSettings$Companion {
+	public final fun getSettings ()Lcom/arkivanov/decompose/DecomposeSettings;
+	public final fun setSettings (Lcom/arkivanov/decompose/DecomposeSettings;)V
+}
+
 public final class com/arkivanov/decompose/DeeplinkUtilsKt {
 	public static final fun handleDeepLink (Landroid/app/Activity;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }

--- a/decompose/api/decompose.klib.api
+++ b/decompose/api/decompose.klib.api
@@ -482,6 +482,25 @@ final class <#A: out kotlin/Any> com.arkivanov.decompose.router.pages/Pages { //
     }
 }
 
+final class com.arkivanov.decompose/DecomposeSettings { // com.arkivanov.decompose/DecomposeSettings|null[0]
+    constructor <init>(kotlin/Boolean = ...) // com.arkivanov.decompose/DecomposeSettings.<init>|<init>(kotlin.Boolean){}[0]
+
+    final val duplicateConfigurationsEnabled // com.arkivanov.decompose/DecomposeSettings.duplicateConfigurationsEnabled|{}duplicateConfigurationsEnabled[0]
+        final fun <get-duplicateConfigurationsEnabled>(): kotlin/Boolean // com.arkivanov.decompose/DecomposeSettings.duplicateConfigurationsEnabled.<get-duplicateConfigurationsEnabled>|<get-duplicateConfigurationsEnabled>(){}[0]
+
+    final fun component1(): kotlin/Boolean // com.arkivanov.decompose/DecomposeSettings.component1|component1(){}[0]
+    final fun copy(kotlin/Boolean = ...): com.arkivanov.decompose/DecomposeSettings // com.arkivanov.decompose/DecomposeSettings.copy|copy(kotlin.Boolean){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.arkivanov.decompose/DecomposeSettings.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.arkivanov.decompose/DecomposeSettings.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.arkivanov.decompose/DecomposeSettings.toString|toString(){}[0]
+
+    final object Companion { // com.arkivanov.decompose/DecomposeSettings.Companion|null[0]
+        final var settings // com.arkivanov.decompose/DecomposeSettings.Companion.settings|{}settings[0]
+            final fun <get-settings>(): com.arkivanov.decompose/DecomposeSettings // com.arkivanov.decompose/DecomposeSettings.Companion.settings.<get-settings>|<get-settings>(){}[0]
+            final fun <set-settings>(com.arkivanov.decompose/DecomposeSettings) // com.arkivanov.decompose/DecomposeSettings.Companion.settings.<set-settings>|<set-settings>(com.arkivanov.decompose.DecomposeSettings){}[0]
+    }
+}
+
 final class com.arkivanov.decompose/DefaultComponentContext : com.arkivanov.decompose/ComponentContext { // com.arkivanov.decompose/DefaultComponentContext|null[0]
     constructor <init>(com.arkivanov.essenty.lifecycle/Lifecycle) // com.arkivanov.decompose/DefaultComponentContext.<init>|<init>(com.arkivanov.essenty.lifecycle.Lifecycle){}[0]
     constructor <init>(com.arkivanov.essenty.lifecycle/Lifecycle, com.arkivanov.essenty.statekeeper/StateKeeper? = ..., com.arkivanov.essenty.instancekeeper/InstanceKeeper? = ..., com.arkivanov.essenty.backhandler/BackHandler? = ...) // com.arkivanov.decompose/DefaultComponentContext.<init>|<init>(com.arkivanov.essenty.lifecycle.Lifecycle;com.arkivanov.essenty.statekeeper.StateKeeper?;com.arkivanov.essenty.instancekeeper.InstanceKeeper?;com.arkivanov.essenty.backhandler.BackHandler?){}[0]

--- a/decompose/api/jvm/decompose.api
+++ b/decompose/api/jvm/decompose.api
@@ -66,6 +66,25 @@ public final class com/arkivanov/decompose/DecomposeExperimentFlags {
 	public final fun setDuplicateConfigurationsEnabled (Z)V
 }
 
+public final class com/arkivanov/decompose/DecomposeSettings {
+	public static final field Companion Lcom/arkivanov/decompose/DecomposeSettings$Companion;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/arkivanov/decompose/DecomposeSettings;
+	public static synthetic fun copy$default (Lcom/arkivanov/decompose/DecomposeSettings;ZILjava/lang/Object;)Lcom/arkivanov/decompose/DecomposeSettings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuplicateConfigurationsEnabled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/arkivanov/decompose/DecomposeSettings$Companion {
+	public final fun getSettings ()Lcom/arkivanov/decompose/DecomposeSettings;
+	public final fun setSettings (Lcom/arkivanov/decompose/DecomposeSettings;)V
+}
+
 public final class com/arkivanov/decompose/DefaultComponentContext : com/arkivanov/decompose/ComponentContext {
 	public fun <init> (Lcom/arkivanov/essenty/lifecycle/Lifecycle;)V
 	public fun <init> (Lcom/arkivanov/essenty/lifecycle/Lifecycle;Lcom/arkivanov/essenty/statekeeper/StateKeeper;Lcom/arkivanov/essenty/instancekeeper/InstanceKeeper;Lcom/arkivanov/essenty/backhandler/BackHandler;)V

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DecomposeExperimentFlags.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DecomposeExperimentFlags.kt
@@ -3,5 +3,12 @@ package com.arkivanov.decompose
 @ExperimentalDecomposeApi
 object DecomposeExperimentFlags {
 
-    var duplicateConfigurationsEnabled: Boolean = false
+    @Deprecated(
+        message = "The feature has been promoted to stable. Please use DecomposeSettings.duplicateConfigurationsEnabled instead.",
+    )
+    var duplicateConfigurationsEnabled: Boolean
+        get() = DecomposeSettings.settings.duplicateConfigurationsEnabled
+        set(value) {
+            DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = value)
+        }
 }

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DecomposeSettings.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DecomposeSettings.kt
@@ -1,0 +1,19 @@
+package com.arkivanov.decompose
+
+import kotlin.concurrent.Volatile
+
+/**
+ * Global Decompose settings. Use [DecomposeSettings.settings] property to change the settings.
+ *
+ * @param duplicateConfigurationsEnabled controls whether duplicate configurations are enabled or not. Default value is `false`.
+ * Excludes the `Child Items` navigation model, which doesn't support duplicate configurations.
+ */
+data class DecomposeSettings(
+    val duplicateConfigurationsEnabled: Boolean = false,
+) {
+
+    companion object {
+        @Volatile
+        var settings: DecomposeSettings = DecomposeSettings()
+    }
+}

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/Utils.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/Utils.kt
@@ -15,16 +15,21 @@ internal expect val KClass<*>.uniqueName: String?
 
 internal val Lifecycle.isDestroyed: Boolean get() = state == Lifecycle.State.DESTROYED
 
-internal fun <T : Any, C : Any> List<T>.keyed(configuration: (T) -> C): Map<Any, T> {
-    val numbers = HashMap<C, Int>()
+internal fun <T : Any, C : Any> List<T>.keyed(configuration: (T) -> C): Map<ItemKey, T> {
+    val indices = HashMap<C, Int>()
 
     return associateBy { item ->
         val config = configuration(item)
-        val number = (numbers[config] ?: 0) + 1
-        numbers[config] = number
-        config to number
+        val index = indices[config]?.plus(1) ?: 0
+        indices[config] = index
+        ItemKey(config, index)
     }
 }
+
+internal data class ItemKey(
+    private val value: Any,
+    private val index: Int,
+)
 
 internal fun <T : Any> Iterable<T>.findFirstDuplicate(set: Set<T>): Pair<Int, T>? {
     val iter1 = iterator()

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/children/ChildItem.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/children/ChildItem.kt
@@ -10,14 +10,18 @@ internal sealed interface ChildItem<out C : Any, out T : Any> {
 
     val configuration: C
     val instance: T?
+    val lifecycleRegistry: LifecycleRegistry?
+    val stateKeeperDispatcher: StateKeeperDispatcher?
+    val instanceKeeperDispatcher: InstanceKeeperDispatcher?
+    val backHandler: ChildBackHandler?
 
     data class Created<out C : Any, out T : Any>(
         override val configuration: C,
         override val instance: T,
-        val lifecycleRegistry: LifecycleRegistry,
-        val stateKeeperDispatcher: StateKeeperDispatcher,
-        val instanceKeeperDispatcher: InstanceKeeperDispatcher,
-        val backHandler: ChildBackHandler,
+        override val lifecycleRegistry: LifecycleRegistry,
+        override val stateKeeperDispatcher: StateKeeperDispatcher,
+        override val instanceKeeperDispatcher: InstanceKeeperDispatcher,
+        override val backHandler: ChildBackHandler,
     ) : ChildItem<C, T>
 
     data class Destroyed<out C : Any>(
@@ -25,5 +29,9 @@ internal sealed interface ChildItem<out C : Any, out T : Any> {
         val savedState: SerializableContainer? = null
     ) : ChildItem<C, Nothing> {
         override val instance: Nothing? = null
+        override val lifecycleRegistry: LifecycleRegistry? = null
+        override val stateKeeperDispatcher: StateKeeperDispatcher? = null
+        override val instanceKeeperDispatcher: InstanceKeeperDispatcher? = null
+        override val backHandler: ChildBackHandler? = null
     }
 }

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/children/ChildrenFactory.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/children/ChildrenFactory.kt
@@ -69,8 +69,12 @@ fun <Ctx : GenericComponentContext<Ctx>, C : Any, T : Any, E : Any, N : NavState
  * The API is based around [NavState] and [ChildNavState] interfaces that should be implemented by
  * clients. [NavState] represents a persistent state of the navigation. It also holds a navigation
  * state for each child - [ChildNavState]. Both [NavState] and [ChildNavState] must be immutable, and
- * correctly implement `equals` and `hashCode` methods (or just be data classes). There must be no
- * duplicated (by equality) [ChildNavState.configuration] within a [NavState].
+ * correctly implement `equals` and `hashCode` methods (or just be data classes).
+ *
+ * By default, having duplicate (by equality) configurations ([ChildNavState.configuration]) within
+ * a [NavState] is prohibited. Decompose will throw an exception when detected. However, duplicate
+ * configurations can be enabled by setting the
+ * [com.arkivanov.decompose.DecomposeSettings.duplicateConfigurationsEnabled] flag to `true`.
  *
  * The navigation is performed by transforming the current [NavState] to a new one. The implementation
  * calculates diffs between the old list of [ChildNavState] and the new one, and manipulates child

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/items/ChildItemsFactory.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/items/ChildItemsFactory.kt
@@ -13,6 +13,9 @@ import kotlinx.serialization.KSerializer
 /**
  * Initializes and manages a list of components with arbitrary lifecycle states. Typically used for lazy lists.
  *
+ * Please note that this navigation model does not support duplicate (by equality) configurations.
+ * A runtime exception will be thrown if duplicate configurations are detected.
+ *
  * **It is strongly recommended to call this method on the Main thread.**
  *
  * @param source a source of navigation events.
@@ -43,6 +46,9 @@ fun <Ctx : GenericComponentContext<Ctx>, C : Any, T : Any> Ctx.childItems(
 
 /**
  * Initializes and manages a list of components with arbitrary lifecycle states. Typically used for lazy lists.
+ *
+ * Please note that this navigation model does not support duplicate (by equality) configurations.
+ * A runtime exception will be thrown if duplicate configurations are detected.
  *
  * **It is strongly recommended to call this method on the Main thread.**
  *

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/items/Items.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/items/Items.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 /**
  * Represents a state of Child Items navigation model.
  *
- * @param items a list of child configurations, can be empty. Must be unique even if the
- * [com.arkivanov.decompose.DecomposeExperimentFlags.duplicateConfigurationsEnabled] flag is enabled.
+ * @param items a list of child configurations, can be empty. Must be unique.
+ * A runtime exception will be thrown if duplicate configurations are detected.
  * @param activeItems a map of lifecycle states of the instantiated (active) components.
  * Child components whose configurations are not present in this map are destroyed.
  * Configurations in the map should also be present in the [items] list,

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/pages/ChildPagesFactory.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/pages/ChildPagesFactory.kt
@@ -17,6 +17,10 @@ import kotlinx.serialization.Serializable
  * Initializes and manages a list of components with one selected (active) component.
  * The list can be empty.
  *
+ * By default, having duplicate (by equality) configurations [C] within [Pages.items] is prohibited.
+ * Decompose will throw an exception when detected. However, duplicate configurations can be enabled
+ * by setting [com.arkivanov.decompose.DecomposeSettings.duplicateConfigurationsEnabled] flag to `true`.
+ *
  * **It is strongly recommended to call this method on the Main thread.**
  *
  * @param source a source of navigation events.
@@ -83,6 +87,10 @@ private class SerializablePages<out C : Any>(
 /**
  * Initializes and manages a list of components with one selected (active) component.
  * The list can be empty.
+ *
+ * By default, having duplicate (by equality) configurations [C] within [Pages.items] is prohibited.
+ * Decompose will throw an exception when detected. However, duplicate configurations can be enabled
+ * by setting [com.arkivanov.decompose.DecomposeSettings.duplicateConfigurationsEnabled] flag to `true`.
  *
  * **It is strongly recommended to call this method on the Main thread.**
  *

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/pages/Pages.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/pages/Pages.kt
@@ -5,7 +5,9 @@ import kotlinx.serialization.Serializable
 /**
  * Represents a state of Child Pages navigation model.
  *
- * @param items a list of child configurations, must be unique, can be empty.
+ * @param items a list of child configurations, can be empty. Must be unique
+ * unless duplicate configurations were enabled, see
+ * [com.arkivanov.decompose.DecomposeSettings.duplicateConfigurationsEnabled].
  * @param selectedIndex an index of the selected child configuration.
  * Must be within the range of [items] indices if [items] is not empty, otherwise can be any number.
  */

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/ChildStackFactory.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/router/stack/ChildStackFactory.kt
@@ -1,7 +1,6 @@
 package com.arkivanov.decompose.router.stack
 
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.GenericComponentContext
 import com.arkivanov.decompose.router.children.ChildNavState.Status
 import com.arkivanov.decompose.router.children.NavState
@@ -17,13 +16,17 @@ import kotlinx.serialization.builtins.ListSerializer
 /**
  * Initializes and manages a stack of components.
  *
+ * By default, having duplicate (by equality) configurations [C] within the stack is prohibited.
+ * Decompose will throw an exception when detected. However, duplicate configurations can be enabled
+ * by setting [com.arkivanov.decompose.DecomposeSettings.duplicateConfigurationsEnabled] flag to `true`.
+ *
  * **It is strongly recommended to call this method on the Main thread.**
  *
  * @param source a source of navigation events.
  * @param serializer an optional [KSerializer] to be used for serializing and deserializing configurations.
  * If `null` then the navigation state will not be preserved.
  * @param initialStack a stack of component configurations (ordered from tail to head) that should be set
- * if there is no saved state, must be not empty and unique.
+ * if there is no saved state, must be not empty and unique (unless duplicate configurations were enabled).
  * @param key a key of the navigation, must be unique if there are multiple stacks in the same component.
  * @param handleBackButton determines whether the stack should be automatically popped on back button press or not,
  * default is `false`.
@@ -61,9 +64,23 @@ fun <Ctx : GenericComponentContext<Ctx>, C : Any, T : Any> Ctx.childStack(
     )
 
 /**
- * A convenience extension function for [ComponentContext.childStack].
+ * Initializes and manages a stack of components.
+ *
+ * By default, having duplicate (by equality) configurations [C] within the stack is prohibited.
+ * Decompose will throw an exception when detected. However, duplicate configurations can be enabled
+ * by setting [com.arkivanov.decompose.DecomposeSettings.duplicateConfigurationsEnabled] flag to `true`.
  *
  * **It is strongly recommended to call this method on the Main thread.**
+ *
+ * @param source a source of navigation events.
+ * @param serializer an optional [KSerializer] to be used for serializing and deserializing configurations.
+ * If `null` then the navigation state will not be preserved.
+ * @param initialConfiguration an initial configuration that should be set if there is no saved state.
+ * @param key a key of the navigation, must be unique if there are multiple stacks in the same component.
+ * @param handleBackButton determines whether the stack should be automatically popped on back button press or not,
+ * default is `false`.
+ * @param childFactory a factory function that creates new child instances.
+ * @return an observable [Value] of [ChildStack].
  */
 fun <Ctx : GenericComponentContext<Ctx>, C : Any, T : Any> Ctx.childStack(
     source: NavigationSource<StackNavigation.Event<C>>,
@@ -85,11 +102,15 @@ fun <Ctx : GenericComponentContext<Ctx>, C : Any, T : Any> Ctx.childStack(
 /**
  * Initializes and manages a stack of components.
  *
+ * By default, having duplicate (by equality) configurations [C] within the stack is prohibited.
+ * Decompose will throw an exception when detected. However, duplicate configurations can be enabled
+ * by setting [com.arkivanov.decompose.DecomposeSettings.duplicateConfigurationsEnabled] flag to `true`.
+ *
  * **It is strongly recommended to call this method on the Main thread.**
  *
  * @param source a source of navigation events.
  * @param initialStack a stack of component configurations (ordered from tail to head) that should be set
- * if there is no saved state, must be not empty and unique.
+ * if there is no saved state, must be not empty and unique (unless duplicate configurations were enabled).
  * @param saveStack a function that saves the provided stack of configurations into [SerializableContainer].
  * The navigation state is not saved if `null` is returned.
  * @param restoreStack a function that restores the stack of configuration from the provided [SerializableContainer].

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenBasicTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenBasicTest.kt
@@ -1,6 +1,6 @@
 package com.arkivanov.decompose.router.children
 
-import com.arkivanov.decompose.DecomposeExperimentFlags
+import com.arkivanov.decompose.DecomposeSettings
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.router.TestInstance
 import com.arkivanov.decompose.router.children.ChildNavState.Status.CREATED
@@ -221,7 +221,7 @@ class ChildrenBasicTest : ChildrenTestBase() {
 
     @Test
     fun WHEN_add_duplicated_children_THEN_duplicated_children_added() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val children by context.children(initialState = stateOf(1 by DESTROYED, 2 by CREATED, 3 by STARTED, 4 by RESUMED))
 
         navigate { it + listOf(1 by RESUMED, 2 by RESUMED, 3 by RESUMED) }
@@ -231,7 +231,7 @@ class ChildrenBasicTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_duplicated_children_WHEN_remove_duplicated_children_from_end_THEN_duplicated_children_removed() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
 
         val children by context.children(
             initialState = stateOf(
@@ -255,7 +255,7 @@ class ChildrenBasicTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_duplicated_children_WHEN_remove_duplicated_children_from_end_THEN_duplicated_instances_removed_from_end() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
 
         val children by context.children(
             initialState = stateOf(
@@ -278,7 +278,7 @@ class ChildrenBasicTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_duplicated_children_WHEN_remove_duplicated_children_from_start_THEN_duplicated_children_removed() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
 
         val children by context.children(
             initialState = stateOf(
@@ -297,7 +297,7 @@ class ChildrenBasicTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_duplicated_children_WHEN_remove_duplicated_children_from_start_THEN_duplicated_instances_removed_from_end() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
 
         val children by context.children(
             initialState = stateOf(

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenLifecycleTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenLifecycleTest.kt
@@ -1,6 +1,6 @@
 package com.arkivanov.decompose.router.children
 
-import com.arkivanov.decompose.DecomposeExperimentFlags
+import com.arkivanov.decompose.DecomposeSettings
 import com.arkivanov.decompose.router.children.ChildNavState.Status.CREATED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.DESTROYED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.RESUMED
@@ -284,7 +284,7 @@ class ChildrenLifecycleTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_first_and_last_children_duplicated_WHEN_last_child_removed_THEN_last_child_destroyed() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val children by context.children(initialState = stateOf(1 by CREATED, 2 by STARTED, 1 by RESUMED))
         val child = children.last().requireInstance()
 
@@ -295,7 +295,7 @@ class ChildrenLifecycleTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_first_and_last_children_duplicated_first_child_created_WHEN_last_child_removed_THEN_first_child_created() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val children by context.children(initialState = stateOf(1 by CREATED, 2 by STARTED, 1 by RESUMED))
         val child = children.first().requireInstance()
 
@@ -306,7 +306,7 @@ class ChildrenLifecycleTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_first_and_last_children_duplicated_WHEN_first_child_removed_THEN_last_child_destroyed() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val children by context.children(initialState = stateOf(1 by CREATED, 2 by STARTED, 1 by RESUMED))
         val child = children.last().requireInstance()
 
@@ -317,7 +317,7 @@ class ChildrenLifecycleTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_first_and_last_children_duplicated_and_last_child_resumed_WHEN_first_child_removed_THEN_first_child_resumed() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val children by context.children(initialState = stateOf(1 by CREATED, 2 by STARTED, 1 by RESUMED))
         val child = children.first().requireInstance()
 

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenRetainedInstanceTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenRetainedInstanceTest.kt
@@ -1,6 +1,6 @@
 package com.arkivanov.decompose.router.children
 
-import com.arkivanov.decompose.DecomposeExperimentFlags
+import com.arkivanov.decompose.DecomposeSettings
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.router.TestInstance
 import com.arkivanov.decompose.router.children.ChildNavState.Status.CREATED
@@ -265,7 +265,7 @@ class ChildrenRetainedInstanceTest : ChildrenTestBase() {
 
     @Test
     fun WHEN_duplicated_children_recreated_THEN_instances_retained() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val oldStateKeeper = TestStateKeeperDispatcher()
         val instanceKeeper = InstanceKeeperDispatcher()
         val oldContext = DefaultComponentContext(lifecycle = lifecycle, stateKeeper = oldStateKeeper, instanceKeeper = instanceKeeper)
@@ -286,7 +286,7 @@ class ChildrenRetainedInstanceTest : ChildrenTestBase() {
 
     @Test
     fun WHEN_duplicated_children_recreated_THEN_instances_not_destroyed() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val oldStateKeeper = TestStateKeeperDispatcher()
         val instanceKeeper = InstanceKeeperDispatcher()
         val oldContext = DefaultComponentContext(lifecycle = lifecycle, stateKeeper = oldStateKeeper, instanceKeeper = instanceKeeper)

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenSavedStateTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenSavedStateTest.kt
@@ -1,6 +1,6 @@
 package com.arkivanov.decompose.router.children
 
-import com.arkivanov.decompose.DecomposeExperimentFlags
+import com.arkivanov.decompose.DecomposeSettings
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.router.children.ChildNavState.Status.CREATED
 import com.arkivanov.decompose.router.children.ChildNavState.Status.DESTROYED
@@ -561,7 +561,7 @@ class ChildrenSavedStateTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_first_and_last_children_duplicated_WHEN_recreated_THEN_states_restored() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val oldStateKeeper = TestStateKeeperDispatcher()
         val oldContext = DefaultComponentContext(lifecycle = lifecycle, stateKeeper = oldStateKeeper)
         val oldChildren by oldContext.children(initialState = stateOf(1 by CREATED, 2 by STARTED, 1 by RESUMED))
@@ -582,7 +582,7 @@ class ChildrenSavedStateTest : ChildrenTestBase() {
 
     @Test
     fun GIVEN_first_and_last_children_duplicated_WHEN_children_recreated_THEN_states_restored() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val children by context.children(initialState = stateOf(1 by CREATED, 2 by STARTED, 1 by RESUMED))
         children.first().requireInstance().stateKeeper.register("key") { 10 }
         children.last().requireInstance().stateKeeper.register("key") { 30 }

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenTestBase.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/children/ChildrenTestBase.kt
@@ -2,7 +2,7 @@ package com.arkivanov.decompose.router.children
 
 import com.arkivanov.decompose.Child
 import com.arkivanov.decompose.ComponentContext
-import com.arkivanov.decompose.DecomposeExperimentFlags
+import com.arkivanov.decompose.DecomposeSettings
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.statekeeper.TestStateKeeperDispatcher
 import com.arkivanov.decompose.value.Value
@@ -38,7 +38,7 @@ open class ChildrenTestBase {
 
     @AfterTest
     fun after() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = false
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = false)
     }
 
     protected fun ComponentContext.children(

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/stack/ChildStackIntegrationTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/stack/ChildStackIntegrationTest.kt
@@ -1,7 +1,7 @@
 package com.arkivanov.decompose.router.stack
 
 import com.arkivanov.decompose.ComponentContext
-import com.arkivanov.decompose.DecomposeExperimentFlags
+import com.arkivanov.decompose.DecomposeSettings
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.DelicateDecomposeApi
 import com.arkivanov.decompose.lifecycle.TestLifecycleCallbacks
@@ -65,7 +65,7 @@ class ChildStackIntegrationTest {
 
     @AfterTest
     fun after() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = false
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = false)
     }
 
     @Test
@@ -611,7 +611,7 @@ class ChildStackIntegrationTest {
 
     @Test
     fun WHEN_push_duplicated_children_THEN_stack_contains_duplicated_children() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val stack by context.childStack(initialStack = listOf(Config(1), Config(2), Config(3)))
 
         navigation.push(Config(1))
@@ -622,7 +622,7 @@ class ChildStackIntegrationTest {
 
     @Test
     fun GIVEN_stack_with_duplicated_children_WHEN_remove_duplicated_children_THEN_stack_contains_unique_children() {
-        DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
+        DecomposeSettings.settings = DecomposeSettings.settings.copy(duplicateConfigurationsEnabled = true)
         val stack by context.childStack(initialStack = listOf(Config(1), Config(2), Config(3), Config(1), Config(2)))
 
         navigation.pop()

--- a/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/stack/RouterPushToFrontTest.kt
+++ b/decompose/src/commonTest/kotlin/com/arkivanov/decompose/router/stack/RouterPushToFrontTest.kt
@@ -41,4 +41,30 @@ class RouterPushToFrontTest {
 
         assertEquals(listOf(1, 2, 3), navigator.configurations)
     }
+
+    @Test
+    fun WHEN_exists_duplicated_at_start_and_middle_THEN_middle_configuration_moved_to_end() {
+        val navigator = TestStackNavigator(listOf(1, 1, 3))
+
+        navigator.pushToFront(1)
+
+        assertEquals(listOf(1, 3, 1), navigator.configurations)
+    }
+
+    @Test
+    fun WHEN_exists_duplicated_at_start_and_end_THEN_not_changed() {
+        val navigator = TestStackNavigator(listOf(1, 2, 1))
+
+        navigator.pushToFront(1)
+
+        assertEquals(listOf(1, 2, 1), navigator.configurations)
+    }
+    @Test
+    fun WHEN_exists_duplicated_in_the_middle_and_end_THEN_not_changed() {
+        val navigator = TestStackNavigator(listOf(1, 2, 2))
+
+        navigator.pushToFront(2)
+
+        assertEquals(listOf(1, 2, 2), navigator.configurations)
+    }
 }


### PR DESCRIPTION
Related to #928.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable DecomposeSettings to control duplicate-configuration behavior.

* **Improvements**
  * pushToFront now handles duplicates by removing prior occurrences before re-adding.
  * Children restoration and navigation use a unified keyed approach for consistent behavior.

* **Documentation**
  * Expanded docs clarifying duplicate-configuration rules and how to enable them via DecomposeSettings.

* **Deprecations**
  * Previous experimental flag usage deprecated in favor of DecomposeSettings.

* **Tests**
  * Added and updated tests covering duplicate handling and pushToFront scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->