### PR TITLE
Removed onBeforeNavigate callback from DefaultSharedTransitionsComponent

### DIFF
--- a/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/sharedtransitions/DefaultSharedTransitionsComponent.kt
+++ b/sample/shared/shared/src/commonMain/kotlin/com/arkivanov/sample/shared/sharedtransitions/DefaultSharedTransitionsComponent.kt
@@ -62,7 +62,6 @@ class DefaultSharedTransitionsComponent(
                     is Config.Photo -> mapOf("id" to config.id.toString())
                 }
             },
-            onBeforeNavigate = { false },
         )
 
     private fun child(config: Config, ctx: ComponentContext): Child =


### PR DESCRIPTION
Seems like it was added by mistake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation handling to use default behavior, allowing navigation events to proceed as expected without unnecessary pre-checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->