### PR TITLE
Added DecomposeSettings#onDecomposeError setting, deprecated onDecomposeError callback

### DIFF
--- a/decompose/api/android/decompose.api
+++ b/decompose/api/android/decompose.api
@@ -71,15 +71,17 @@ public final class com/arkivanov/decompose/DecomposeExperimentFlags {
 public final class com/arkivanov/decompose/DecomposeSettings {
 	public static final field Companion Lcom/arkivanov/decompose/DecomposeSettings$Companion;
 	public fun <init> ()V
-	public fun <init> (ZZ)V
-	public synthetic fun <init> (ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (ZZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
-	public final fun copy (ZZ)Lcom/arkivanov/decompose/DecomposeSettings;
-	public static synthetic fun copy$default (Lcom/arkivanov/decompose/DecomposeSettings;ZZILjava/lang/Object;)Lcom/arkivanov/decompose/DecomposeSettings;
+	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (ZZLkotlin/jvm/functions/Function1;)Lcom/arkivanov/decompose/DecomposeSettings;
+	public static synthetic fun copy$default (Lcom/arkivanov/decompose/DecomposeSettings;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/arkivanov/decompose/DecomposeSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDuplicateConfigurationsEnabled ()Z
 	public final fun getMainThreadCheckEnabled ()Z
+	public final fun getOnDecomposeError ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/decompose/api/decompose.klib.api
+++ b/decompose/api/decompose.klib.api
@@ -483,16 +483,19 @@ final class <#A: out kotlin/Any> com.arkivanov.decompose.router.pages/Pages { //
 }
 
 final class com.arkivanov.decompose/DecomposeSettings { // com.arkivanov.decompose/DecomposeSettings|null[0]
-    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ...) // com.arkivanov.decompose/DecomposeSettings.<init>|<init>(kotlin.Boolean;kotlin.Boolean){}[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Function1<kotlin/Exception, kotlin/Unit> = ...) // com.arkivanov.decompose/DecomposeSettings.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Function1<kotlin.Exception,kotlin.Unit>){}[0]
 
     final val duplicateConfigurationsEnabled // com.arkivanov.decompose/DecomposeSettings.duplicateConfigurationsEnabled|{}duplicateConfigurationsEnabled[0]
         final fun <get-duplicateConfigurationsEnabled>(): kotlin/Boolean // com.arkivanov.decompose/DecomposeSettings.duplicateConfigurationsEnabled.<get-duplicateConfigurationsEnabled>|<get-duplicateConfigurationsEnabled>(){}[0]
     final val mainThreadCheckEnabled // com.arkivanov.decompose/DecomposeSettings.mainThreadCheckEnabled|{}mainThreadCheckEnabled[0]
         final fun <get-mainThreadCheckEnabled>(): kotlin/Boolean // com.arkivanov.decompose/DecomposeSettings.mainThreadCheckEnabled.<get-mainThreadCheckEnabled>|<get-mainThreadCheckEnabled>(){}[0]
+    final val onDecomposeError // com.arkivanov.decompose/DecomposeSettings.onDecomposeError|{}onDecomposeError[0]
+        final fun <get-onDecomposeError>(): kotlin/Function1<kotlin/Exception, kotlin/Unit> // com.arkivanov.decompose/DecomposeSettings.onDecomposeError.<get-onDecomposeError>|<get-onDecomposeError>(){}[0]
 
     final fun component1(): kotlin/Boolean // com.arkivanov.decompose/DecomposeSettings.component1|component1(){}[0]
     final fun component2(): kotlin/Boolean // com.arkivanov.decompose/DecomposeSettings.component2|component2(){}[0]
-    final fun copy(kotlin/Boolean = ..., kotlin/Boolean = ...): com.arkivanov.decompose/DecomposeSettings // com.arkivanov.decompose/DecomposeSettings.copy|copy(kotlin.Boolean;kotlin.Boolean){}[0]
+    final fun component3(): kotlin/Function1<kotlin/Exception, kotlin/Unit> // com.arkivanov.decompose/DecomposeSettings.component3|component3(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Function1<kotlin/Exception, kotlin/Unit> = ...): com.arkivanov.decompose/DecomposeSettings // com.arkivanov.decompose/DecomposeSettings.copy|copy(kotlin.Boolean;kotlin.Boolean;kotlin.Function1<kotlin.Exception,kotlin.Unit>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.arkivanov.decompose/DecomposeSettings.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.arkivanov.decompose/DecomposeSettings.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.arkivanov.decompose/DecomposeSettings.toString|toString(){}[0]

--- a/decompose/api/jvm/decompose.api
+++ b/decompose/api/jvm/decompose.api
@@ -71,15 +71,17 @@ public final class com/arkivanov/decompose/DecomposeExperimentFlags {
 public final class com/arkivanov/decompose/DecomposeSettings {
 	public static final field Companion Lcom/arkivanov/decompose/DecomposeSettings$Companion;
 	public fun <init> ()V
-	public fun <init> (ZZ)V
-	public synthetic fun <init> (ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (ZZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
-	public final fun copy (ZZ)Lcom/arkivanov/decompose/DecomposeSettings;
-	public static synthetic fun copy$default (Lcom/arkivanov/decompose/DecomposeSettings;ZZILjava/lang/Object;)Lcom/arkivanov/decompose/DecomposeSettings;
+	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (ZZLkotlin/jvm/functions/Function1;)Lcom/arkivanov/decompose/DecomposeSettings;
+	public static synthetic fun copy$default (Lcom/arkivanov/decompose/DecomposeSettings;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/arkivanov/decompose/DecomposeSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDuplicateConfigurationsEnabled ()Z
 	public final fun getMainThreadCheckEnabled ()Z
+	public final fun getOnDecomposeError ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DecomposeSettings.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DecomposeSettings.kt
@@ -1,5 +1,6 @@
 package com.arkivanov.decompose
 
+import com.arkivanov.decompose.errorhandler.printError
 import kotlin.concurrent.Volatile
 
 /**
@@ -10,10 +11,12 @@ import kotlin.concurrent.Volatile
  * @param mainThreadCheckEnabled controls whether main thread checks are enabled or not.
  * If enabled, Decompose will log an error if it detects access from a background thread when it was expected from the main thread.
  * Default value is `true`.
+ * @param onDecomposeError called when a non-fatal error has occurred in Decompose. By default, prints the error to logs.
  */
 data class DecomposeSettings(
     val duplicateConfigurationsEnabled: Boolean = false,
     val mainThreadCheckEnabled: Boolean = true,
+    val onDecomposeError: (Exception) -> Unit = ::printError,
 ) {
 
     companion object {

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/errorhandler/ErrorHandlers.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/errorhandler/ErrorHandlers.kt
@@ -1,6 +1,13 @@
 package com.arkivanov.decompose.errorhandler
 
+import com.arkivanov.decompose.DecomposeSettings
+
 /**
  * Called when a non-fatal error has occurred in Decompose.
  */
-var onDecomposeError: (Exception) -> Unit = ::printError
+@Deprecated(message = "Please use DecomposeSettings#onDecomposeError")
+var onDecomposeError: (Exception) -> Unit
+    get() = DecomposeSettings.settings.onDecomposeError
+    set(value) {
+        DecomposeSettings.update { it.copy(onDecomposeError = value) }
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DecomposeSettings gains a configurable onDecomposeError callback so callers can customize how decomposition errors are handled (defaults to the previous behavior).

* **Deprecations**
  * Legacy top-level error handler API is deprecated — migrate to DecomposeSettings.onDecomposeError for configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->