### PR TITLE
Updated docs for Duplicate Configurations

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,12 +37,14 @@ This exception is thrown when duplicated component configurations are detected b
 - Prefer `pushNew` function instead of `push` when showing a component on a button click, it will properly handle accidental double clicks.
 - Prefer `pushToFront` to prevent duplicated components with the same data (configurations) in the stack.
 
-### The experimental Duplicate Configurations mode
+### The Duplicate Configurations mode
 
-You can also try enabling the experimental Duplicate Configurations mode using the following flag:
+!!!note
 
-```kotlin
-DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
-```
+    The feature is stable since version `3.5.0-alpha01`.
 
-This will allow having duplicate configurations in all navigation models. Please keep in mind that this feature is experimental.
+Most navigation models (such as Child Stack and Child Pages) can support duplication configurations. The feature is opt-in, it can be enabled via the [DecomposeSettings](https://github.com/arkivanov/Decompose/blob/master/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DecomposeSettings.kt) `duplicateConfigurationsEnabled` global property since version `3.5.0-alpha01` or via `DecomposeExperimentFlags#duplicateConfigurationsEnabled` flag on earlier versions.
+
+If this mode is enabled, Decompose will not throw errors when duplicate configurations are detected and will try its best to handle duplicates gracefully.
+
+The only navigation model that does not support duplicate configurations is Child Items.

--- a/docs/navigation/items/overview.md
+++ b/docs/navigation/items/overview.md
@@ -30,7 +30,7 @@ Similarly to other navigation models, each component created and managed by the 
 
 - Configurations must be unique (by equality) within `Child Items`.
 
-### The experimental Duplicate Configurations mode
+### The Duplicate Configurations mode
 
 Unlike other navigation models, the `Child Items` navigation model doesn't support the Duplicate Configurations mode. `IllegalStateException` is thrown if duplicate configurations are detected, regardless of the `DecomposeExperimentFlags.duplicateConfigurationsEnabled` flag.
 

--- a/docs/navigation/pages/overview.md
+++ b/docs/navigation/pages/overview.md
@@ -26,15 +26,15 @@ Similarly to `Child Stack`, each component created and managed by the `Child Pag
 
 - Configurations must be unique (by equality) within `Child Pages`.
 
-### The experimental Duplicate Configurations mode
+### The Duplicate Configurations mode
 
-You can also try enabling the experimental Duplicate Configurations mode using the following flag:
+!!!note
 
-```kotlin
-DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
-```
+    The feature is stable since version `3.5.0-alpha01`.
 
-This will allow having duplicate configurations in all navigation models. Please keep in mind that this feature is experimental.
+The Child Pages navigation model can support duplication configurations. The feature is opt-in, it can be enabled via the [DecomposeSettings](https://github.com/arkivanov/Decompose/blob/master/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DecomposeSettings.kt) `duplicateConfigurationsEnabled` global property since version `3.5.0-alpha01` or via `DecomposeExperimentFlags#duplicateConfigurationsEnabled` flag on earlier versions.
+
+If this mode is enabled, Decompose will not throw errors when duplicate configurations are detected and will try its best to handle duplicates gracefully.
 
 ### Initializing Child Pages
 

--- a/docs/navigation/stack/overview.md
+++ b/docs/navigation/stack/overview.md
@@ -21,15 +21,15 @@ Each component created and managed by the `Child Stack` has a configuration, ple
 
 - Configurations must be unique (by equality) within the `Child Stack`.
 
-### The experimental Duplicate Configurations mode
+### The Duplicate Configurations mode
 
-You can also try enabling the experimental Duplicate Configurations mode using the following flag:
+!!!note
 
-```kotlin
-DecomposeExperimentFlags.duplicateConfigurationsEnabled = true
-```
+    The feature is stable since version `3.5.0-alpha01`.
 
-This will allow having duplicate configurations in all navigation models. Please keep in mind that this feature is experimental.
+The Child Pages navigation model can support duplication configurations. The feature is opt-in, it can be enabled via the [DecomposeSettings](https://github.com/arkivanov/Decompose/blob/master/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DecomposeSettings.kt) `duplicateConfigurationsEnabled` global property since version `3.5.0-alpha01` or via `DecomposeExperimentFlags#duplicateConfigurationsEnabled` flag on earlier versions.
+
+If this mode is enabled, Decompose will not throw errors when duplicate configurations are detected and will try its best to handle duplicates gracefully.
 
 ### Initializing the Child Stack
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Duplicate Configurations mode is now marked as stable (since v3.5.0-alpha01) in documentation, replacing the previous experimental designation.
  * Updated guides to clarify the feature is opt-in and supported across most navigation models, with Child Items as the only exception.
  * Enhanced documentation describing graceful handling of duplicate configurations and related settings behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->