### PR TITLE
Fixed Children composable sometimes sticks with switching the stack quickly

### DIFF
--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/AbstractStackAnimation.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/AbstractStackAnimation.kt
@@ -38,7 +38,10 @@ internal abstract class AbstractStackAnimation<C : Any, T : Any>(
 
             val newItems = getAnimationItems(newStack = currentStack, oldStack = oldStack)
             if (items.size == 1) {
-                items = newItems
+                val oldLastKey = items.keys.last()
+                val (newLastKey, newLastItem) = newItems.entries.last()
+                items = if ((newLastKey != oldLastKey) || newLastItem.direction.isExit) newItems else mapOf(newLastKey to newLastItem)
+                nextItems = null
             } else {
                 nextItems = newItems
             }

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/DefaultStackAnimator.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/DefaultStackAnimator.kt
@@ -7,7 +7,9 @@ import androidx.compose.animation.core.isFinished
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 
 internal class DefaultStackAnimator(
@@ -22,6 +24,7 @@ internal class DefaultStackAnimator(
         onFinished: () -> Unit,
         content: @Composable (Modifier) -> Unit,
     ) {
+        val onFinishedRef by rememberUpdatedState(onFinished)
         val animationState = remember(direction, isInitial) { AnimationState(initialValue = if (isInitial) 0F else 1F) }
 
         LaunchedEffect(animationState) {
@@ -31,7 +34,7 @@ internal class DefaultStackAnimator(
                 sequentialAnimation = !animationState.isFinished,
             )
 
-            onFinished()
+            onFinishedRef()
         }
 
         val factor =


### PR DESCRIPTION
Fixes: #862
Related to: #976


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stack animation behavior during component state transitions for improved reliability.
  * Improved animation completion callback handling to ensure consistent animation performance across recompositions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->