### PR TITLE
Fixed web history rewriting incorrectly when started via a link

### DIFF
--- a/decompose/src/webTest/kotlin/com/arkivanov/decompose/router/webhistory/TestBrowserHistory.kt
+++ b/decompose/src/webTest/kotlin/com/arkivanov/decompose/router/webhistory/TestBrowserHistory.kt
@@ -1,6 +1,7 @@
 package com.arkivanov.decompose.router.webhistory
 
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class TestBrowserHistory : BrowserHistory {
 
@@ -13,7 +14,9 @@ class TestBrowserHistory : BrowserHistory {
 
     override fun go(delta: Int) {
         scheduleOperation {
+            val oldIndex = index
             index += delta
+            assertTrue(index in stack.indices, "Invalid go operation: delta=$delta, index=$oldIndex, range=${stack.indices}")
             onPopStateListener?.invoke(stack[index].data)
         }
     }

--- a/decompose/src/webTest/kotlin/com/arkivanov/decompose/router/webhistory/TestWebNavigation.kt
+++ b/decompose/src/webTest/kotlin/com/arkivanov/decompose/router/webhistory/TestWebNavigation.kt
@@ -6,6 +6,7 @@ import com.arkivanov.decompose.value.Value
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 

--- a/decompose/src/webTest/kotlin/com/arkivanov/decompose/router/webhistory/WebHistoryNavigationTest.kt
+++ b/decompose/src/webTest/kotlin/com/arkivanov/decompose/router/webhistory/WebHistoryNavigationTest.kt
@@ -779,6 +779,25 @@ class WebHistoryNavigationTest {
         assertHistory(nav = nav, urls = listOf("/1/1/1", "/1/1/2"))
     }
 
+    @Test
+    fun GIVEN_created_one_root_and_two_children_WHEN_root_replaced_with_with_one_child_THEN_one_item_in_history() {
+        val nav =
+            TestWebNavigation(initialHistory = listOf(1)) { cfg ->
+                when (cfg) {
+                    1 ->  TestWebNavigation(initialHistory = listOf(12, 13))
+                    2 ->  TestWebNavigation(initialHistory = listOf(22))
+                    else -> null
+                }
+            }
+
+        enableWebHistory(nav, history)
+
+        nav.navigate(listOf(2))
+        history.runPendingOperations()
+
+        assertHistory(nav = nav, urls = listOf("/2/22"))
+    }
+
     private fun assertHistory(nav: TestWebNavigation, urls: List<String>, index: Int = urls.lastIndex) {
         history.assertStack(urls = urls, index = index)
         nav.assertHistory(urls = urls.slice(0..index))


### PR DESCRIPTION
Fixes: #982

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Simplified `onRewrite` callback signature in web history navigation API—now accepts only the navigation history parameter

* **Tests**
  * Enhanced test coverage for web history navigation scenarios, including root replacement with child node transitions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->