### PR TITLE
Removed maven.pkg.jetbrains.space Maven repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 
     dependencies {
@@ -76,6 +75,5 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed JetBrains Compose dev Maven repository from build configuration. Dependency resolution now relies exclusively on mavenCentral() and google() repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->