### PR TITLE
[V4] Removed ExperimentalDecomposeApi annotation from all API in extensions-compose-experimental

### DIFF
--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanels.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanels.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.experimental.BroadcastBackHandler
 import com.arkivanov.decompose.extensions.compose.experimental.rememberLazy
 import com.arkivanov.decompose.extensions.compose.experimental.stack.ChildStack
@@ -45,7 +44,6 @@ import com.arkivanov.decompose.value.Value
  * is not `null`, and disabled if the returned value is `null`.
  * Only works if [ChildPanels.mode] is [ChildPanelsMode.SINGLE].
  */
-@ExperimentalDecomposeApi
 @Composable
 fun <MC : Any, MT : Any, DC : Any, DT : Any> ChildPanels(
     panels: Value<ChildPanels<MC, MT, DC, DT, Nothing, Nothing>>,
@@ -91,7 +89,6 @@ fun <MC : Any, MT : Any, DC : Any, DT : Any> ChildPanels(
  * is not `null`, and disabled if the returned value is `null`.
  * Only works if [ChildPanels.mode] is [ChildPanelsMode.SINGLE].
  */
-@ExperimentalDecomposeApi
 @Composable
 fun <MC : Any, MT : Any, DC : Any, DT : Any> ChildPanels(
     panels: ChildPanels<MC, MT, DC, DT, Nothing, Nothing>,
@@ -140,7 +137,6 @@ fun <MC : Any, MT : Any, DC : Any, DT : Any> ChildPanels(
  * is not `null`, and disabled if the returned value is `null`.
  * Only works if [ChildPanels.mode] is [ChildPanelsMode.SINGLE].
  */
-@ExperimentalDecomposeApi
 @Composable
 fun <MC : Any, MT : Any, DC : Any, DT : Any, EC : Any, ET : Any> ChildPanels(
     panels: Value<ChildPanels<MC, MT, DC, DT, EC, ET>>,
@@ -194,7 +190,6 @@ fun <MC : Any, MT : Any, DC : Any, DT : Any, EC : Any, ET : Any> ChildPanels(
  * is not `null`, and disabled if the returned value is `null`.
  * Only works if [ChildPanels.mode] is [ChildPanelsMode.SINGLE].
  */
-@ExperimentalDecomposeApi
 @Composable
 fun <MC : Any, MT : Any, DC : Any, DT : Any, EC : Any, ET : Any> ChildPanels(
     panels: ChildPanels<MC, MT, DC, DT, EC, ET>,
@@ -253,7 +248,6 @@ fun <MC : Any, MT : Any, DC : Any, DT : Any, EC : Any, ET : Any> ChildPanels(
     }
 }
 
-@ExperimentalDecomposeApi
 @Composable
 private fun <MC : Any, MT : Any> MainPanel(
     main: Child.Created<MC, PanelChild<MC, MT>>,
@@ -287,7 +281,6 @@ private fun <MC : Any, MT : Any> MainPanel(
     }
 }
 
-@ExperimentalDecomposeApi
 @Composable
 private fun <DC : Any, DT : Any> DetailsPanel(
     details: Child.Created<DC, PanelChild<DC, DT>>?,
@@ -329,7 +322,6 @@ private fun <DC : Any, DT : Any> DetailsPanel(
     }
 }
 
-@ExperimentalDecomposeApi
 @Composable
 private fun <EC : Any, ET : Any> ExtraPanel(
     extra: Child.Created<EC, PanelChild<EC, ET>>?,

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanelsAnimators.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanelsAnimators.kt
@@ -1,7 +1,6 @@
 package com.arkivanov.decompose.extensions.compose.experimental.panels
 
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.experimental.stack.animation.StackAnimator
 import com.arkivanov.decompose.extensions.compose.stack.animation.Direction
 import com.arkivanov.decompose.router.panels.ChildPanelsMode
@@ -15,7 +14,6 @@ import com.arkivanov.decompose.router.panels.ChildPanelsMode
  * @param details provides an optional [StackAnimator] for the Details [Child].
  * @param extra provides an optional [StackAnimator] for the Extra [Child].
  */
-@ExperimentalDecomposeApi
 class ChildPanelsAnimators<in MC : Any, in MT : Any, in DC : Any, in DT : Any, in EC : Any, in ET : Any>(
     val main: (Child.Created<MC, MT>, ChildPanelsMode, Direction, isPredictiveBack: Boolean) -> StackAnimator? = { _, _, _, _ -> null },
     val details: (Child.Created<DC, DT>, ChildPanelsMode, Direction, isPredictiveBack: Boolean) -> StackAnimator? = { _, _, _, _ -> null },

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanelsLayout.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/ChildPanelsLayout.kt
@@ -1,13 +1,11 @@
 package com.arkivanov.decompose.extensions.compose.experimental.panels
 
 import androidx.compose.runtime.Composable
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.router.panels.ChildPanelsMode
 
 /**
  * A Child Panels layout used for laying out panels in single, dual and triple modes.
  */
-@ExperimentalDecomposeApi
 interface ChildPanelsLayout {
 
     /**

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/HorizontalChildPanelsLayout.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/panels/HorizontalChildPanelsLayout.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.unit.Constraints
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.router.panels.ChildPanelsMode
 
 /**
@@ -51,7 +50,6 @@ import com.arkivanov.decompose.router.panels.ChildPanelsMode
  * [TRIPLE][com.arkivanov.decompose.router.panels.ChildPanelsMode.TRIPLE] mode.
  * Default values are `1F`, meaning that all panel slots have equal width.
  */
-@ExperimentalDecomposeApi
 class HorizontalChildPanelsLayout(
     private val dualWeights: Pair<Float, Float> = Pair(1F, 1F),
     private val tripleWeights: Triple<Float, Float, Float> = Triple(1F, 1F, 1F),

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/ChildStack.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/ChildStack.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.experimental.stack.animation.LocalStackAnimationProvider
 import com.arkivanov.decompose.extensions.compose.experimental.stack.animation.StackAnimation
 import com.arkivanov.decompose.extensions.compose.experimental.stack.animation.StackAnimationScope
@@ -28,7 +27,6 @@ import com.arkivanov.decompose.value.Value
  * The receiver [StackAnimationScope] can be used for additional animations, such as
  * [Shared Element Transitions](https://developer.android.com/develop/ui/compose/animation/shared-elements).
  */
-@ExperimentalDecomposeApi
 @Composable
 fun <C : Any, T : Any> ChildStack(
     stack: ChildStack<C, T>,
@@ -62,7 +60,6 @@ fun <C : Any, T : Any> ChildStack(
  * The receiver [StackAnimationScope] can be used for additional animations, such as
  * [Shared Element Transitions](https://developer.android.com/develop/ui/compose/animation/shared-elements).
  */
-@ExperimentalDecomposeApi
 @Composable
 fun <C : Any, T : Any> ChildStack(
     stack: Value<ChildStack<C, T>>,

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimation.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.experimental.stack.WithStackAnimationScope
 import com.arkivanov.decompose.extensions.compose.experimental.stack.awaitAll
 import com.arkivanov.decompose.extensions.compose.experimental.stack.dropLast
@@ -33,7 +32,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
-@ExperimentalDecomposeApi
 internal class DefaultStackAnimation<C : Any, T : Any>(
     private val disableInputDuringAnimation: Boolean,
     private val predictiveBackParams: (ChildStack<C, T>) -> PredictiveBackParams?,
@@ -194,7 +192,6 @@ internal class DefaultStackAnimation<C : Any, T : Any>(
                 )
         }
 
-    @ExperimentalDecomposeApi
     @Composable
     private fun PredictiveBackController(
         stack: ChildStack<C, T>,
@@ -385,7 +382,6 @@ private fun Overlay(modifier: Modifier) {
     )
 }
 
-@ExperimentalDecomposeApi
 private data class AnimationItem<out C : Any, out T : Any>(
     val child: Child.Created<C, T>,
     val direction: Direction,
@@ -393,7 +389,6 @@ private data class AnimationItem<out C : Any, out T : Any>(
     val animator: StackAnimator? = null,
 )
 
-@ExperimentalDecomposeApi
 private fun <C : Any, T : Any> keyedItemsOf(vararg items: AnimationItem<C, T>): Map<String, AnimationItem<C, T>> =
     items.associateBy { it.child.key }
 
@@ -402,7 +397,6 @@ private fun <C : Any, T : Any> keyedItemsOf(vararg items: AnimationItem<C, T>): 
  * https://github.com/JetBrains/compose-jb/issues/2688
  * https://github.com/JetBrains/compose-jb/issues/2612
  */
-@ExperimentalDecomposeApi
 private class SimpleStackAnimator(
     private val modifier: () -> Modifier,
 ) : StackAnimator {

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimator.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/DefaultStackAnimator.kt
@@ -7,11 +7,9 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.animation.Direction
 import com.arkivanov.decompose.extensions.compose.stack.animation.isFront
 
-@ExperimentalDecomposeApi
 internal class DefaultStackAnimator(
     private val animationSpec: FiniteAnimationSpec<Float> = tween(),
     private val frame: @Composable (factor: Float, direction: Direction) -> Modifier

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/EmptyStackAnimation.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/EmptyStackAnimation.kt
@@ -8,11 +8,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.experimental.stack.WithStackAnimationScope
 import com.arkivanov.decompose.router.stack.ChildStack
 
-@ExperimentalDecomposeApi
 internal fun <C : Any, T : Any> emptyStackAnimation(): StackAnimation<C, T> =
     EmptyStackAnimation()
 
@@ -21,7 +19,6 @@ internal fun <C : Any, T : Any> emptyStackAnimation(): StackAnimation<C, T> =
  * https://github.com/JetBrains/compose-jb/issues/2688
  * https://github.com/JetBrains/compose-jb/issues/2612
  */
-@ExperimentalDecomposeApi
 private class EmptyStackAnimation<C : Any, T : Any> : StackAnimation<C, T> {
 
     @Composable

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/Fade.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/Fade.kt
@@ -3,16 +3,13 @@ package com.arkivanov.decompose.extensions.compose.experimental.stack.animation
 import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import kotlin.math.abs
 
 /**
  * A simple fading animation. Appearing children's `alpha` is animated from [minAlpha] to 1.0.
  * Disappearing children's `alpha` is animated from 1.0 to [minAlpha].
  */
-@ExperimentalDecomposeApi
 fun fade(
     animationSpec: FiniteAnimationSpec<Float> = tween(),
     minAlpha: Float = 0F,

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/PredictiveBackParams.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/PredictiveBackParams.kt
@@ -1,6 +1,5 @@
 package com.arkivanov.decompose.extensions.compose.experimental.stack.animation
 
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback.PredictiveBackAnimatable
 import com.arkivanov.essenty.backhandler.BackEvent
 import com.arkivanov.essenty.backhandler.BackHandler
@@ -20,7 +19,6 @@ import com.arkivanov.essenty.backhandler.BackHandler
  * @see com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback.androidPredictiveBackAnimatableV1
  * @see com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback.androidPredictiveBackAnimatableV2
  */
-@ExperimentalDecomposeApi
 class PredictiveBackParams(
     val backHandler: BackHandler,
     val onBack: () -> Unit,

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/Scale.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/Scale.kt
@@ -4,13 +4,11 @@ import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.tween
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 
 /**
  * A simple scaling animation. Front (above) children are scaling from [frontFactor] to 1.0.
  * Back (below) children are scaling from 1.0 to [backFactor].
  */
-@ExperimentalDecomposeApi
 fun scale(
     animationSpec: FiniteAnimationSpec<Float> = tween(),
     frontFactor: Float = 1.15F,

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/Slide.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/Slide.kt
@@ -5,14 +5,12 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 
 /**
  * A simple sliding animation. Children enter from one side and exit to another side.
  *
  * You can also invert sliding direction applying [StackAnimator.inverted]
  */
-@ExperimentalDecomposeApi
 fun slide(
     animationSpec: FiniteAnimationSpec<Float> = tween(),
     orientation: Orientation = Orientation.Horizontal,

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/StackAnimation.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/StackAnimation.kt
@@ -3,14 +3,12 @@ package com.arkivanov.decompose.extensions.compose.experimental.stack.animation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.animation.Direction
 import com.arkivanov.decompose.router.stack.ChildStack
 
 /**
  * Tracks the [ChildStack] changes and animates between child widget.
  */
-@ExperimentalDecomposeApi
 fun interface StackAnimation<C : Any, T : Any> {
 
     @Composable
@@ -31,7 +29,6 @@ fun interface StackAnimation<C : Any, T : Any> {
  * @param selector provides an optional [StackAnimator] for the current [Child], other [Child], [Direction] and
  * `isPredictiveBack` flag.
  */
-@ExperimentalDecomposeApi
 fun <C : Any, T : Any> stackAnimation(
     disableInputDuringAnimation: Boolean = true,
     predictiveBackParams: (ChildStack<C, T>) -> PredictiveBackParams? = { null },
@@ -57,7 +54,6 @@ fun <C : Any, T : Any> stackAnimation(
  * or `null`. The predictive back gesture is enabled if the value returned for the specified [ChildStack]
  * is not `null`, and disabled if the returned value is `null`.
  */
-@ExperimentalDecomposeApi
 fun <C : Any, T : Any> stackAnimation(
     animator: StackAnimator? = fade(),
     disableInputDuringAnimation: Boolean = true,

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/StackAnimationProvider.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/StackAnimationProvider.kt
@@ -1,14 +1,11 @@
 package com.arkivanov.decompose.extensions.compose.experimental.stack.animation
 
 import androidx.compose.runtime.compositionLocalOf
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 
-@ExperimentalDecomposeApi
 interface StackAnimationProvider {
     fun <C : Any, T : Any> provide(): StackAnimation<C, T>?
 }
 
-@ExperimentalDecomposeApi
 val LocalStackAnimationProvider =
     compositionLocalOf<StackAnimationProvider> {
         object : StackAnimationProvider {

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/StackAnimationScope.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/StackAnimationScope.kt
@@ -2,14 +2,12 @@ package com.arkivanov.decompose.extensions.compose.experimental.stack.animation
 
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.runtime.Stable
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.animation.Direction
 
 /**
  * A scope interface for [StackAnimation], extends [AnimatedVisibilityScope].
  * Allows better UI customization during stack animations.
  */
-@ExperimentalDecomposeApi
 @Stable
 interface StackAnimationScope : AnimatedVisibilityScope {
 

--- a/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/StackAnimator.kt
+++ b/extensions-compose-experimental/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/experimental/stack/animation/StackAnimator.kt
@@ -4,13 +4,11 @@ import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.animation.Direction
 
 /**
  * Animates a child widget in the given [Direction].
  */
-@ExperimentalDecomposeApi
 fun interface StackAnimator {
 
     /**
@@ -33,7 +31,6 @@ fun interface StackAnimator {
  * - From -1F to 0F for [Direction.ENTER_BACK]
  * - From 0F to -1F for [Direction.EXIT_BACK]
  */
-@ExperimentalDecomposeApi
 fun stackAnimator(
     animationSpec: FiniteAnimationSpec<Float> = tween(),
     frame: @Composable (factor: Float, direction: Direction) -> Modifier,
@@ -51,7 +48,6 @@ fun stackAnimator(
  * - [Direction.EXIT_BACK] -> [Direction.EXIT_FRONT]
  * @return the inverted [StackAnimator]
  */
-@ExperimentalDecomposeApi
 fun StackAnimator.inverted(): StackAnimator =
     StackAnimator { direction ->
         animate(
@@ -67,7 +63,6 @@ fun StackAnimator.inverted(): StackAnimator =
 /**
  * Combines (merges) the receiver [StackAnimator] with the [other] [StackAnimator].
  */
-@ExperimentalDecomposeApi
 operator fun StackAnimator.plus(other: StackAnimator): StackAnimator =
     PlusStackAnimator(first = this, second = other)
 
@@ -76,7 +71,6 @@ operator fun StackAnimator.plus(other: StackAnimator): StackAnimator =
  * https://github.com/JetBrains/compose-jb/issues/2688
  * https://github.com/JetBrains/compose-jb/issues/2612
  */
-@ExperimentalDecomposeApi
 private class PlusStackAnimator(
     private val first: StackAnimator,
     private val second: StackAnimator,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Several stack and panel Compose APIs are now available without requiring experimental opt-in.
  * Animation helpers and providers can be used more directly in app code.

* **Bug Fixes**
  * Reduced friction when integrating stack and panel transitions by removing unnecessary experimental markings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->