### PR TITLE
[V4] Removed ExperimentalDecomposeApi annotation from predictive back gesture API

### DIFF
--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/AbstractStackAnimation.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/AbstractStackAnimation.kt
@@ -10,11 +10,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.utils.InputConsumingOverlay
 import com.arkivanov.decompose.router.stack.ChildStack
 
-@OptIn(ExperimentalDecomposeApi::class)
 internal abstract class AbstractStackAnimation<C : Any, T : Any>(
     private val disableInputDuringAnimation: Boolean,
 ) : StackAnimation<C, T> {

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/MovableStackAnimation.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/MovableStackAnimation.kt
@@ -5,14 +5,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.remember
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 
 internal class MovableStackAnimation<C : Any, T : Any>(
     disableInputDuringAnimation: Boolean,
     private val selector: (child: Child.Created<C, T>, otherChild: Child.Created<C, T>, direction: Direction) -> StackAnimator?,
 ) : AbstractStackAnimation<C, T>(disableInputDuringAnimation = disableInputDuringAnimation) {
 
-    @OptIn(ExperimentalDecomposeApi::class)
     @Composable
     override fun Child(
         item: AnimationItem<C, T>,

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/SimpleStackAnimation.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/SimpleStackAnimation.kt
@@ -4,14 +4,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 
 internal class SimpleStackAnimation<C : Any, T : Any>(
     disableInputDuringAnimation: Boolean,
     private val selector: (Child.Created<C, T>) -> StackAnimator?,
 ) : AbstractStackAnimation<C, T>(disableInputDuringAnimation = disableInputDuringAnimation) {
 
-    @OptIn(ExperimentalDecomposeApi::class)
     @Composable
     override fun Child(
         item: AnimationItem<C, T>,

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/AndroidPredictiveBackAnimatable.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/AndroidPredictiveBackAnimatable.kt
@@ -1,7 +1,6 @@
 package com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback
 
 import androidx.compose.ui.graphics.Shape
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.essenty.backhandler.BackEvent
 
 /**
@@ -16,7 +15,6 @@ import com.arkivanov.essenty.backhandler.BackEvent
  * If not supplied then a [RoundedCornerShape][androidx.compose.foundation.shape.RoundedCornerShape] will be applied.
  * The `progress` argument is animating between 0 and 1 while the gesture is being performed.
  */
-@ExperimentalDecomposeApi
 fun androidPredictiveBackAnimatableV1(
     initialBackEvent: BackEvent,
     exitShape: ((progress: Float, edge: BackEvent.SwipeEdge) -> Shape)? = null,
@@ -41,7 +39,6 @@ fun androidPredictiveBackAnimatableV1(
  * If not supplied then a [RoundedCornerShape][androidx.compose.foundation.shape.RoundedCornerShape] will be applied.
  * The `progress` argument is animating between 0 and 1 while the gesture is being performed.
  */
-@ExperimentalDecomposeApi
 fun androidPredictiveBackAnimatableV2(
     initialBackEvent: BackEvent,
     exitShape: ((progress: Float, edge: BackEvent.SwipeEdge) -> Shape)? = null,

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/AndroidPredictiveBackAnimatableV1.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/AndroidPredictiveBackAnimatableV1.kt
@@ -15,14 +15,12 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.util.lerp
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.essenty.backhandler.BackEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 
-@ExperimentalDecomposeApi
 internal class AndroidPredictiveBackAnimatableV1(
     initialEvent: BackEvent,
     private val exitShape: ((progress: Float, edge: BackEvent.SwipeEdge) -> Shape)? = null,

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/AndroidPredictiveBackAnimatableV2.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/AndroidPredictiveBackAnimatableV2.kt
@@ -1,7 +1,13 @@
 package com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithContent
@@ -16,13 +22,11 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.util.lerp
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.essenty.backhandler.BackEvent
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 
-@ExperimentalDecomposeApi
 internal class AndroidPredictiveBackAnimatableV2(
     private val initialEvent: BackEvent,
     private val exitShape: ((progress: Float, edge: BackEvent.SwipeEdge) -> Shape)?,

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/DefaultPredictiveBackAnimatable.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/DefaultPredictiveBackAnimatable.kt
@@ -5,10 +5,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.essenty.backhandler.BackEvent
 
-@ExperimentalDecomposeApi
 internal class DefaultPredictiveBackAnimatable(
     initialBackEvent: BackEvent,
     private val getExitModifier: (progress: Float, edge: BackEvent.SwipeEdge) -> Modifier,

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/MaterialPredictiveBackAnimatable.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/MaterialPredictiveBackAnimatable.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.essenty.backhandler.BackEvent
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
@@ -35,7 +34,6 @@ import kotlinx.coroutines.launch
  * @param shape an optional clipping shape of the child being removed (the currently active child).
  * If not supplied then a [RoundedCornerShape][androidx.compose.foundation.shape.RoundedCornerShape] will be applied.
  */
-@ExperimentalDecomposeApi
 fun materialPredictiveBackAnimatable(
     initialBackEvent: BackEvent,
     shape: ((progress: Float, edge: BackEvent.SwipeEdge) -> Shape)? = null,
@@ -45,7 +43,6 @@ fun materialPredictiveBackAnimatable(
         exitShape = shape,
     )
 
-@ExperimentalDecomposeApi
 private class MaterialPredictiveBackAnimatable(
     private val initialEvent: BackEvent,
     private val exitShape: ((progress: Float, edge: BackEvent.SwipeEdge) -> Shape)? = null,

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/PredictiveBackAnimatable.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/PredictiveBackAnimatable.kt
@@ -1,7 +1,6 @@
 package com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback
 
 import androidx.compose.ui.Modifier
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.essenty.backhandler.BackEvent
 
 /**
@@ -9,7 +8,6 @@ import com.arkivanov.essenty.backhandler.BackEvent
  *
  * [Animatable][androidx.compose.animation.core.Animatable] can be used for animations.
  */
-@ExperimentalDecomposeApi
 interface PredictiveBackAnimatable {
 
     /**
@@ -63,7 +61,6 @@ interface PredictiveBackAnimatable {
  * @param enterModifier a function that returns a [Modifier] for every gesture event, for
  * the previous child (behind the currently active child).
  */
-@ExperimentalDecomposeApi
 fun predictiveBackAnimatable(
     initialBackEvent: BackEvent,
     exitModifier: (progress: Float, edge: BackEvent.SwipeEdge) -> Modifier,

--- a/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/PredictiveBackAnimation.kt
+++ b/extensions-compose/src/commonMain/kotlin/com/arkivanov/decompose/extensions/compose/stack/animation/predictiveback/PredictiveBackAnimation.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.Ref
 import com.arkivanov.decompose.extensions.compose.stack.animation.LocalStackAnimationProvider
 import com.arkivanov.decompose.extensions.compose.stack.animation.StackAnimation
@@ -37,7 +36,6 @@ import kotlinx.coroutines.launch
  * returns [PredictiveBackAnimatable] responsible for animations.
  * @param onBack a callback that is called when the gesture is finished.
  */
-@ExperimentalDecomposeApi
 fun <C : Any, T : Any> predictiveBackAnimation(
     backHandler: BackHandler,
     fallbackAnimation: StackAnimation<C, T>? = null,
@@ -57,7 +55,6 @@ fun <C : Any, T : Any> predictiveBackAnimation(
         onBack = onBack,
     )
 
-@OptIn(ExperimentalDecomposeApi::class)
 private class PredictiveBackAnimation<C : Any, T : Any>(
     private val backHandler: BackHandler,
     private val animation: StackAnimation<C, T>?,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed experimental API requirements from stack animation and predictive-back components, making them easier to use without extra opt-in annotations.
  * Cleaned up predictive-back related imports and updated internal references for consistency.

* **Style**
  * Minor formatting and import organization updates across animation-related code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->