### PR TITLE
[V4] Removed unnecessary ExperimentalDecomposeApi annotation from samples

### DIFF
--- a/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/counters/CountersContent.kt
+++ b/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/counters/CountersContent.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.Children
 import com.arkivanov.decompose.extensions.compose.stack.animation.fade
 import com.arkivanov.decompose.extensions.compose.stack.animation.plus
@@ -21,7 +20,6 @@ import com.arkivanov.sample.shared.counters.counter.CounterContent
 import com.arkivanov.sample.shared.utils.TopAppBar
 import com.arkivanov.sample.shared.utils.WebDocumentTitle
 
-@OptIn(ExperimentalDecomposeApi::class)
 @Composable
 internal fun CountersContent(component: CountersComponent, modifier: Modifier = Modifier) {
     WebDocumentTitle(title = "Counters")

--- a/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/root/RootContent.kt
+++ b/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/root/RootContent.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.Children
 import com.arkivanov.decompose.extensions.compose.stack.animation.fade
 import com.arkivanov.decompose.extensions.compose.stack.animation.plus
@@ -34,7 +33,6 @@ fun RootContent(component: RootComponent, modifier: Modifier = Modifier) {
     }
 }
 
-@OptIn(ExperimentalDecomposeApi::class)
 @Composable
 private fun Children(component: RootComponent, modifier: Modifier = Modifier) {
     Children(

--- a/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/sharedtransitions/SharedTransitionsContent.kt
+++ b/sample/shared/compose/src/commonMain/kotlin/com/arkivanov/sample/shared/sharedtransitions/SharedTransitionsContent.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.experimental.stack.ChildStack
 import com.arkivanov.decompose.extensions.compose.experimental.stack.animation.PredictiveBackParams
 import com.arkivanov.decompose.extensions.compose.experimental.stack.animation.fade
@@ -20,7 +19,7 @@ import com.arkivanov.sample.shared.sharedtransitions.SharedTransitionsComponent.
 import com.arkivanov.sample.shared.sharedtransitions.gallery.GalleryContent
 import com.arkivanov.sample.shared.sharedtransitions.photo.PhotoContent
 
-@OptIn(ExperimentalSharedTransitionApi::class, ExperimentalDecomposeApi::class)
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 internal fun SharedTransitionsContent(
     component: SharedTransitionsComponent,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up experimental API usage across shared UI screens.
  * Reduced the need for broad opt-in annotations while keeping app behavior unchanged.
  * Navigation, previews, and screen layouts remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->